### PR TITLE
feat: enable opening multiple files via context menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ The extension supports multiple ways to configure your Python environment:
 3. **Context menu from File Explorer**:
 
    - Right-click on any supported file (or folder)
-   - Select "Open in Scientific Data Viewer"
+   - Select "Open Scientific Data Viewer" for single file or folder
+   - Select "Open Scientific Data Viewer for Selection" to open multiple selected multiple files or folders
    - Command "View: Split Editor" is NOT supported
 
 4. **From command palette**:

--- a/package.json
+++ b/package.json
@@ -56,6 +56,11 @@
                 "category": "Scientific Data Viewer"
             },
             {
+                "command": "scientificDataViewer.openViewerMultiple",
+                "title": "Open Scientific Data Viewer for Selection",
+                "category": "Scientific Data Viewer"
+            },
+            {
                 "command": "scientificDataViewer.openViewerFolder",
                 "title": "Open Scientific Data Viewer (Folder)",
                 "category": "Scientific Data Viewer"
@@ -98,6 +103,11 @@
                     "when": "resourceExtname == .nc || resourceExtname == .netcdf || resourceExtname == .zarr || resourceExtname == .h5 || resourceExtname == .hdf5 || resourceExtname == .grib || resourceExtname == .grib2 || resourceExtname == .grb || resourceExtname == .tif || resourceExtname == .tiff || resourceExtname == .geotiff || resourceExtname == .jp2 || resourceExtname == .jpeg2000 || resourceExtname == .safe || resourceExtname == .nc4 || resourceExtname == .cdf",
                     "command": "scientificDataViewer.openViewer",
                     "group": "navigation"
+                },
+                {
+                    "when": "resourceExtname == .nc || resourceExtname == .netcdf || resourceExtname == .zarr || resourceExtname == .h5 || resourceExtname == .hdf5 || resourceExtname == .grib || resourceExtname == .grib2 || resourceExtname == .grb || resourceExtname == .tif || resourceExtname == .tiff || resourceExtname == .geotiff || resourceExtname == .jp2 || resourceExtname == .jpeg2000 || resourceExtname == .safe || resourceExtname == .nc4 || resourceExtname == .cdf",
+                    "command": "scientificDataViewer.openViewerMultiple",
+                    "group": "navigation"
                 }
             ],
             "commandPalette": [
@@ -135,6 +145,10 @@
                 },
                 {
                     "command": "scientificDataViewer.python.installPackages",
+                    "when": "false"
+                },
+                {
+                    "command": "scientificDataViewer.openViewerMultiple",
                     "when": "false"
                 }
             ],

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -6,6 +6,7 @@ export const SDV_EXTENSION_ID = 'scientificDataViewer';
 
 // Command names
 export const CMD_OPEN_VIEWER = 'scientificDataViewer.openViewer';
+export const CMD_OPEN_VIEWER_MULTIPLE = 'scientificDataViewer.openViewerMultiple';
 export const CMD_OPEN_VIEWER_FOLDER = 'scientificDataViewer.openViewerFolder';
 export const CMD_REFRESH_PYTHON_ENVIRONMENT = 'scientificDataViewer.refreshPythonEnvironment';
 export const CMD_SHOW_LOGS = 'scientificDataViewer.showLogs';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,6 +24,7 @@ import { formatConfigValue } from './common/utils';
 import {
     SDV_EXTENSION_ID,
     CMD_OPEN_VIEWER,
+    CMD_OPEN_VIEWER_MULTIPLE,
     CMD_OPEN_VIEWER_FOLDER,
     CMD_REFRESH_PYTHON_ENVIRONMENT,
     CMD_SHOW_LOGS,
@@ -115,6 +116,15 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             CMD_OPEN_VIEWER,
             commandHandlerOpenViewer(
+                iconPath,
+                webviewOptions,
+                webviewPanelOptions,
+                pythonManager
+            )
+        ),
+        vscode.commands.registerCommand(
+            CMD_OPEN_VIEWER_MULTIPLE,
+            commandHandlerOpenViewerMultiple(
                 iconPath,
                 webviewOptions,
                 webviewPanelOptions,
@@ -579,6 +589,42 @@ function commandHandlerOpenViewer(
                 );
             });
         }
+    };
+}
+
+function commandHandlerOpenViewerMultiple(
+    iconPath: vscode.Uri,
+    webviewOptions: vscode.WebviewOptions,
+    webviewPanelOptions: vscode.WebviewPanelOptions,
+    pythonManager: PythonManager
+): (clickedUri: vscode.Uri, allSelectedUriList: vscode.Uri[]) => void {
+    return async (clickedUri: vscode.Uri, allSelectedUriList: vscode.Uri[]) => {
+        Logger.info('🎮 👁️ 📄📄 Command: Open multiple data viewers...');
+        // Context selection is the clicked file or folder (ignored in this handler)
+        Logger.debug(`🎮 👁️ 📄📄 Command arguments: clickedUri: ${clickedUri}`);
+        // All selections is the list of all selected files or folders (we want it to be opened in data viewers)
+        Logger.debug(`🎮 👁️ 📄📄 Command arguments: allSelectedUriList: [${allSelectedUriList.join(" , ")}]`);
+        
+        // Try to use command arguments (if VSCode passes them)
+        if (!(allSelectedUriList && allSelectedUriList.length > 0)) {
+            Logger.info('🎮 👁️ 📄📄 No files to open, ignore this command.');
+            return;
+        }
+
+        Logger.info(`🎮 👁️ 📄📄 Found ${allSelectedUriList.length} files from command arguments`);
+        for (const uri of allSelectedUriList) {
+            if (uri instanceof vscode.Uri) {
+                Logger.info(`🎮 👁️ 📄📄 Opening data viewer for file: ${uri.fsPath}`);
+                await waitThenCreateOrRevealPanel(
+                    uri,
+                    iconPath,
+                    webviewOptions,
+                    webviewPanelOptions,
+                    pythonManager
+                );
+            }
+        }
+        Logger.info(`🎮 👁️ 📄📄 Opened ${allSelectedUriList.length} files in data viewers`);
     };
 }
 


### PR DESCRIPTION
- Add new command 'scientificDataViewer.openViewerMultiple' for multiple file selection
- Update context menu to support both single and multiple file operations
- Implement command handler that receives clickedUri and allSelectedUriList parameters
- Add command constant CMD_OPEN_VIEWER_MULTIPLE in config
- Update README with simplified multiple file selection instructions
- Support opening multiple files by right-clicking on selected files in Explorer

closes #83 (Multiple file selection via context menu functionality)