### PR TITLE
feat: Add command to toggle dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
     - src/DataViewerPanel.ts - Added exportWebview() method
     - src/extension.ts - Added command handler
     - src/panel/webview/webview-script.js - Added content capture functionality
+- **Dev Mode Toggle Command**: Quick access to enable/disable dev mode without navigating settings
+  - **Command Palette Integration**: "Scientific Data Viewer: Toggle Dev Mode" command
+  - **Global Setting Update**: Updates user's global dev mode setting
+  - **User Feedback**: Clear messages about dev mode state changes
+  - **Developer Experience**: Significantly improves workflow when switching between development and usage
+  - **Files Modified**:
+    - src/common/config.ts - Added updateDevMode function and CMD_TOGGLE_DEV_MODE constant
+    - package.json - Added command definition and menu integration
+    - src/extension.ts - Added command handler with proper error handling
 
 ### Enhanced
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Access these commands via the Command Palette (<kbd>Ctrl</kbd>+<kbd>Shift</kbd>+
 | `Scientific Data Viewer: Open Developer Tools`                 | Opens the developer tools for the webview                                       |
 | `Scientific Data Viewer: Manage Extension Virtual Environment` | View status and manage the extension environment (create, update, delete, info) |
 | `Scientific Data Viewer: Export Webview Content`               | Export the active Scientific Data Viewer as a self-contained HTML report        |
+| `Scientific Data Viewer: Toggle Dev Mode`                      | Quickly enable/disable dev mode without navigating settings                      |
 
 ### 🖱️ Context Menu Commands
 
@@ -483,7 +484,7 @@ npm run lint
 Note: It is recommended to run the task `start-watch-mode` for hot reload with
 <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>P</kbd> Tasks: Run Task then `start-watch-mode`.
 
-Note: It is recommended to enable the `scientificDataViewer.devMode` feature flag during development.
+Note: It is recommended to enable the `scientificDataViewer.devMode` feature flag during development. You can quickly toggle dev mode using the "Scientific Data Viewer: Toggle Dev Mode" command.
 
 **About debugging the error handling**
 

--- a/ensure.sh
+++ b/ensure.sh
@@ -6,7 +6,7 @@
 set -e  # Exit on any error
 
 echo "🔬 Scientific Data Viewer - Ensure Script"
-echo "=============================================="
+echo "-----------------------------------------"
 
 # Use Node.js 22
 source ~/.nvm/nvm.sh && nvm use 22

--- a/package.json
+++ b/package.json
@@ -100,6 +100,11 @@
                 "command": "scientificDataViewer.exportWebview",
                 "title": "Export Webview Content",
                 "category": "Scientific Data Viewer"
+            },
+            {
+                "command": "scientificDataViewer.toggleDevMode",
+                "title": "Toggle Dev Mode",
+                "category": "Scientific Data Viewer"
             }
         ],
         "menus": {
@@ -159,6 +164,10 @@
                 {
                     "command": "scientificDataViewer.openViewerMultiple",
                     "when": "false"
+                },
+                {
+                    "command": "scientificDataViewer.toggleDevMode",
+                    "when": "true"
                 }
             ],
             "view/title": [

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,7 @@
 set -e  # Exit on any error
 
 echo "🔬 Scientific Data Viewer - Development Setup"
-echo "=============================================="
+echo "---------------------------------------------"
 
 # Check if Node.js is installed
 if ! command -v node &> /dev/null; then

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -17,6 +17,7 @@ export const CMD_EXPAND_ALL = 'scientificDataViewer.expandAll';
 export const CMD_PYTHON_INSTALL_PACKAGES = 'scientificDataViewer.python.installPackages';
 export const CMD_MANAGE_EXTENSION_OWN_ENVIRONMENT = 'scientificDataViewer.manageExtensionOwnEnvironment';
 export const CMD_EXPORT_WEBVIEW = 'scientificDataViewer.exportWebview';
+export const CMD_TOGGLE_DEV_MODE = 'scientificDataViewer.toggleDevMode';
 
 // Tree view ID
 export const OUTLINE_TREE_VIEW_ID = 'scientificDataViewer.outline';
@@ -115,5 +116,13 @@ export async function updateUseExtensionOwnEnvironment(
         USE_EXTENSION_OWN_ENVIRONMENT,
         value,
         vscode.ConfigurationTarget.Workspace
+    );
+}
+
+export async function updateDevMode(value: boolean): Promise<void> {
+    return await getWorkspaceConfig().update(
+        DEV_MODE,
+        value,
+        vscode.ConfigurationTarget.Global
     );
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,12 +35,14 @@ import {
     CMD_PYTHON_INSTALL_PACKAGES,
     CMD_MANAGE_EXTENSION_OWN_ENVIRONMENT,
     CMD_EXPORT_WEBVIEW,
+    CMD_TOGGLE_DEV_MODE,
     OUTLINE_TREE_VIEW_ID,
     getDevMode,
     getOverridePythonInterpreter,
     getOverridePythonInterpreterConfigFullKey,
     getUseExtensionOwnEnvironment,
     getUseExtensionOwnEnvironmentConfigFullKey,
+    updateDevMode,
 } from './common/config';
 import { updateStatusBarItem } from './StatusBarItem';
 
@@ -178,6 +180,10 @@ export function activate(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             CMD_EXPORT_WEBVIEW,
             commandHandlerExportWebview()
+        ),
+        vscode.commands.registerCommand(
+            CMD_TOGGLE_DEV_MODE,
+            commandHandlerToggleDevMode()
         )
     );
     Logger.info(`🧩 🚀 Commands registered successfully`);
@@ -428,6 +434,28 @@ function commandHandlerExportWebview(): () => void {
                 `Failed to export webview content: ${
                     error instanceof Error ? error.message : String(error)
                 }`
+            );
+        }
+    };
+}
+
+function commandHandlerToggleDevMode(): () => void {
+    return async () => {
+        Logger.info('🎮 🔧 Command: Toggle Dev Mode');
+        const currentDevMode = getDevMode();
+        const newDevMode = !currentDevMode;
+        
+        try {
+            await updateDevMode(newDevMode);
+            const status = newDevMode ? 'enabled' : 'disabled';
+            Logger.info(`🔧 Dev Mode ${status}`);
+            vscode.window.showInformationMessage(
+                `Dev Mode ${status}. ${newDevMode ? 'Extension logs and developer tools will open automatically when opening scientific data files.' : 'Automatic opening of logs and developer tools is disabled.'}`
+            );
+        } catch (error) {
+            Logger.error(`Failed to toggle dev mode: ${error}`);
+            vscode.window.showErrorMessage(
+                `Failed to toggle dev mode: ${error}`
             );
         }
     };


### PR DESCRIPTION
- Add 'Toggle Dev Mode' command to command palette
- Implement command handler that toggles dev mode setting
- Add updateDevMode function to config.ts
- Update package.json with new command definition
- Command provides quick access to enable/disable dev mode without navigating settings
- Shows informative messages about dev mode state changes

Resolves #86