### PR TITLE
Fix hardcoded viridis colormap to use xarray auto-detection (issue #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
   - **Files Modified**:
     - src/panel/webview/webview-script.js - Use format_info.display_name for format display
 
+- **Issue #103**: Fixed hardcoded viridis colormap preventing xarray from using appropriate colormaps
+  - **Problem**: All plots used hardcoded `cmap="viridis"`, which is inappropriate for diverging data (e.g., data centered around zero)
+  - **Solution**: Removed hardcoded colormap parameter to let xarray automatically determine the appropriate colormap based on data characteristics
+  - **Files Modified**:
+    - python/get_data_info.py - Removed `cmap="viridis"` from all plot.imshow() calls
+
 - **Issue #108**: Fixed attributes being truncated in text representations
   - **Root Cause**: xarray display options had `display_expand_attrs=False` and `display_expand_data=False` applied to text representations, causing attributes and data to show only counts (e.g., `Attributes: (3)`) instead of actual values
   - **Solution**: Updated `XR_TEXT_OPTIONS` to use `display_expand_attrs=True` and `display_expand_data=True` for text representations, ensuring full attribute and data display

--- a/python/get_data_info.py
+++ b/python/get_data_info.py
@@ -1148,29 +1148,25 @@ def create_plot(
             if strategy == "2d_classic":
                 # 2D spatial data - plot directly with appropriate colormap
                 logger.info("Creating 2D spatial plot")
-                var.plot.imshow(cmap="viridis")
+                var.plot.imshow()
                 plt.gca().set_aspect("equal")
             elif strategy == "2d_classic_isel":
                 logger.info("Creating 2D spatial plot with isel")
                 first_dim = var.dims[0]
-                var.isel({first_dim: 0}).plot.imshow(cmap="viridis")
+                var.isel({first_dim: 0}).plot.imshow()
                 plt.gca().set_aspect("equal")
             elif strategy == "3d_col":
                 # 3D data with spatial dimensions - use col parameter
                 logger.info("Creating 3D plot with col parameter")
                 first_dim = var.dims[0]
                 col_wrap = min(4, var.shape[0])
-                var.plot.imshow(
-                    col=first_dim, cmap="viridis", aspect=1, size=4, col_wrap=col_wrap
-                )
+                var.plot.imshow(col=first_dim, aspect=1, size=4, col_wrap=col_wrap)
             elif strategy == "4d_col_row":
                 # 4D data with spatial dimensions - use col and row parameters
                 logger.info("Creating 4D plot with col and row parameters")
                 first_dim = var.dims[0]
                 second_dim = var.dims[1]
-                var.plot.imshow(
-                    col=second_dim, row=first_dim, cmap="viridis", aspect=1, size=4
-                )
+                var.plot.imshow(col=second_dim, row=first_dim, aspect=1, size=4)
             else:
                 # Default plotting behavior - let xarray decide the best method
                 logger.info("Creating default plot using xarray's native plotting")


### PR DESCRIPTION
Remove hardcoded cmap="viridis" from all plot.imshow() calls to let xarray automatically determine the appropriate colormap based on data characteristics (e.g., diverging colormaps for data centered around zero).