### PR TITLE
Pull Request: v0.10.0 — Collapsible nested attributes view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
 
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [0.10.0] - 2026-03-17
+
+### Added
+
+- **Issue #120**: Collapsible nested attributes view for Zarr and other formats
+  - **Problem**: Zarr (and similar formats) store attributes in JSON (e.g. `.zattrs`). The SDV view showed only one level of attributes; nested structures were hard to read.
+  - **Solution**: New optional **Nested Attributes View** (feature flag `scientificDataViewer.nestedAttributesView`, default `false`). When enabled, group attributes are rendered as an expandable/collapsible tree so users can browse the full nested structure. Supports nested objects and arrays.
+  - **Files modified**:
+    - src/common/config.ts — `NESTED_ATTRIBUTES_VIEW`, `getNestedAttributesView()`, `getExtensionConfigForWebview()` so the webview receives a plain config object with all feature flags
+    - package.json — new setting `scientificDataViewer.nestedAttributesView`, version 0.10.0
+    - src/panel/UIController.ts — use `getExtensionConfigForWebview()` in `handleGetExtensionConfig()`
+    - src/panel/webview/webview-script.js — `renderAttributesTree()`, and in `renderGroup()` use tree when `nestedAttributesView` is true
+    - src/panel/webview/styles.css — `.attributes-tree-node`, `.attribute-tree-summary`, `.attributes-tree-children` for tree styling
+  - **Test data**: python/create_sample_data.py — `create_sample_zarr_deeply_nested_attributes()` creates `sample_zarr_deeply_nested_attrs.zarr` with 5–10 levels of nested `.zattrs` for regression and manual testing.
+  - **Upstream**: Release notes document the need for improved representation of nested attributes in xarray; users may open or support a feature request on the xarray project.
+
+### Changed
+
+- Extension config sent to the webview is now a plain object built via `getExtensionConfigForWebview()` (including `nestedAttributesView`) instead of the raw WorkspaceConfiguration, so the webview reliably receives all feature flags.
+
 ## [0.9.0] - 2026-03-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extension to explore the metadata of scientific data files within your IDE, i
 
 <div align="center">
 
-**Current Version: v0.9.0** • [Release Notes](./docs/RELEASE_NOTES_0.9.0.md)
+**Current Version: v0.10.0** • [Release Notes](./docs/RELEASE_NOTES_0.10.0.md)
 
 Available on:
 [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=eschalk0.scientific-data-viewer) • [Open VSX Registry](https://open-vsx.org/extension/eschalk0/scientific-data-viewer)
@@ -37,6 +37,7 @@ Available on:
 - **File Tree Integration**: Right-click on supported files in the explorer to open them
 - **Custom Editors**: Direct file opening with dedicated editors
 - **Interactive Data Explorer**: Browse file structure, dimensions, variables, and attributes
+- **Collapsible Nested Attributes** (opt-in): Tree view for Zarr and other formats with nested JSON attributes (see [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)); enable via **Nested Attributes View** setting
 - **Browse Variable Information**: View variable dimension names, data types, shapes, and memory usage
 - **Basic Data Visualization**: Create plots and visualizations directly in VSCode **(experimental, best effort)**
 - **Enhanced GeoTIFF Support**: Multi-band GeoTIFF files automatically convert bands to separate variables for improved readability and plotting
@@ -359,6 +360,12 @@ The extension includes configuration options that act as feature flags to contro
 - **`scientificDataViewer.groupDimensionSlices`**
   - (type: `boolean`, default: `true`)
   - Show **Group Dimension Slices** per group (dimension inputs, facet row/col, x/y/hue, bins) in each group’s Plot Controls section. Per-field inheritance: group value when set (non-empty), else global. Only dimension slices are atomic (whole group set or whole global).
+
+**Display (attributes)**
+
+- **`scientificDataViewer.nestedAttributesView`**
+  - (type: `boolean`, default: `true`)
+  - When enabled, group attributes are shown as an **expandable/collapsible tree** instead of a flat list. Useful for Zarr (and similar) where attributes are stored as nested JSON (e.g. `.zattrs`). On by default. See [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120).
 
 ## 🔧 Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Available on:
 - **File Tree Integration**: Right-click on supported files in the explorer to open them
 - **Custom Editors**: Direct file opening with dedicated editors
 - **Interactive Data Explorer**: Browse file structure, dimensions, variables, and attributes
-- **Collapsible Nested Attributes** (opt-in): Tree view for Zarr and other formats with nested JSON attributes (see [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)); enable via **Nested Attributes View** setting
+- **Collapsible Nested Attributes** (on by default): Tree view for Zarr and other formats with nested JSON attributes (see [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)); opt out via **Nested Attributes View** setting to use a flat list
 - **Browse Variable Information**: View variable dimension names, data types, shapes, and memory usage
 - **Basic Data Visualization**: Create plots and visualizations directly in VSCode **(experimental, best effort)**
 - **Enhanced GeoTIFF Support**: Multi-band GeoTIFF files automatically convert bands to separate variables for improved readability and plotting
@@ -365,7 +365,7 @@ The extension includes configuration options that act as feature flags to contro
 
 - **`scientificDataViewer.nestedAttributesView`**
   - (type: `boolean`, default: `true`)
-  - When enabled, group attributes are shown as an **expandable/collapsible tree** instead of a flat list. Useful for Zarr (and similar) where attributes are stored as nested JSON (e.g. `.zattrs`). On by default. See [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120).
+  - When on (default), group attributes are shown as an **expandable/collapsible tree** instead of a flat list. Useful for Zarr (and similar) where attributes are stored as nested JSON (e.g. `.zattrs`). Set to `false` to opt out and use the flat list. See [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120).
 
 ## 🔧 Troubleshooting
 

--- a/docs/RELEASE_NOTES_0.10.0.md
+++ b/docs/RELEASE_NOTES_0.10.0.md
@@ -46,10 +46,10 @@ After updating to 0.10.0, the nested attributes tree is **off by default**. To u
 
 ## Summary of changes
 
-| Area            | Change                                                                 |
-|-----------------|------------------------------------------------------------------------|
-| **UI**          | Optional collapsible tree for group attributes (Zarr and others)     |
-| **Settings**    | New `scientificDataViewer.nestedAttributesView` (boolean, default false) |
-| **Test data**   | New Zarr sample with deeply nested `.zattrs` for Issue #120            |
-| **Config**      | Webview receives a plain config object including `nestedAttributesView` |
-| **Docs**        | Release notes, CHANGELOG, README updated; xarray upstream noted       |
+| Area          | Change                                                                   |
+| ------------- | ------------------------------------------------------------------------ |
+| **UI**        | Optional collapsible tree for group attributes (Zarr and others)         |
+| **Settings**  | New `scientificDataViewer.nestedAttributesView` (boolean, default false) |
+| **Test data** | New Zarr sample with deeply nested `.zattrs` for Issue #120              |
+| **Config**    | Webview receives a plain config object including `nestedAttributesView`  |
+| **Docs**      | Release notes, CHANGELOG, README updated; xarray upstream noted          |

--- a/docs/RELEASE_NOTES_0.10.0.md
+++ b/docs/RELEASE_NOTES_0.10.0.md
@@ -1,24 +1,24 @@
 # Scientific Data Viewer v0.10.0 Release Notes
 
-**TL;DR** — **Collapsible nested attributes view** (Issue #120): optional tree view for Zarr (and other formats) that store attributes as nested JSON. Enable via **Nested Attributes View** setting (off by default). Test data script now generates a Zarr store with deeply nested `.zattrs` for QA. Version bump to **0.10.0**.
+**TL;DR** — **Collapsible nested attributes view** (Issue #120): tree view for Zarr (and other formats) that store attributes as nested JSON. **On by default**; you can opt out via **Nested Attributes View** setting to use a flat list. Test data script now generates a Zarr store with deeply nested `.zattrs` for QA. Version bump to **0.10.0**.
 
 ## Collapsible nested attributes view (Issue #120)
 
-Formats such as **Zarr** store group attributes in JSON (e.g. `.zattrs`). The previous UI showed only one level of attributes; nested structures were hard to read. This release adds an optional **tree view** so you can expand and collapse the full attribute hierarchy.
+Formats such as **Zarr** store group attributes in JSON (e.g. `.zattrs`). The previous UI showed only one level of attributes; nested structures were hard to read. This release adds a **tree view** (on by default) so you can expand and collapse the full attribute hierarchy.
 
-### Feature flag (opt-in)
+### Feature flag (on by default, opt-out)
 
 - **Setting:** `scientificDataViewer.nestedAttributesView`
-- **Default:** `false` (opt-in for initial release)
+- **Default:** `true` (tree view on; set to `false` to use a flat list)
 - **Location:** VS Code Settings → Scientific Data Viewer (or `.vscode/settings.json`)
 
-When enabled, the **Attributes** section for each group is rendered as an expandable/collapsible tree instead of a flat list. Nested objects and arrays are shown as nodes you can open to inspect deeper levels. This is especially useful for Zarr datasets with complex metadata (e.g. CF conventions, producer-specific `.zattrs`).
+When on (default), the **Attributes** section for each group is rendered as an expandable/collapsible tree instead of a flat list. Nested objects and arrays are shown as nodes you can open to inspect deeper levels. This is especially useful for Zarr datasets with complex metadata (e.g. CF conventions, producer-specific `.zattrs`). Set the setting to `false` if you prefer the previous flat attribute list.
 
 ### Use cases
 
 - **Zarr users:** Open a Zarr dataset with complex `.zattrs` and expand the tree to see the full nested structure without copying JSON elsewhere.
 - **Metadata inspection:** Browse the attribute tree in-context while viewing dimensions and variables.
-- **Gradual rollout:** The feature is off by default so it can be validated with a subset of users before potentially becoming the default.
+- **Opt-out:** The feature is on by default; disable **Nested Attributes View** in settings to use the flat list instead.
 
 ### Technical notes
 
@@ -34,7 +34,7 @@ The sample data script (`python/create_sample_data.py`) now creates a Zarr store
 - **Content:** Minimal array plus root `.zattrs` with 5–10 levels of nested dicts and mixed arrays/objects.
 - **Purpose:** Regression testing and manual QA of the collapsible nested-attributes UI.
 
-Run the script (e.g. from the repo root) to generate all sample files, including this one. Open the generated Zarr in the viewer and enable **Nested Attributes View** to see the tree.
+Run the script (e.g. from the repo root) to generate all sample files, including this one. Open the generated Zarr in the viewer; the tree is shown by default (disable **Nested Attributes View** in settings to use the flat list).
 
 ## xarray and nested attributes (upstream)
 
@@ -42,14 +42,14 @@ The current xarray and SDV text/HTML representations show attributes in a limite
 
 ## Upgrading
 
-After updating to 0.10.0, the nested attributes tree is **off by default**. To use it, enable **Nested Attributes View** in extension settings. No other breaking changes in this release.
+After updating to 0.10.0, the nested attributes tree is **on by default**. You can opt out by setting **Nested Attributes View** to `false` in extension settings to use the flat list. No other breaking changes in this release.
 
 ## Summary of changes
 
-| Area          | Change                                                                   |
-| ------------- | ------------------------------------------------------------------------ |
-| **UI**        | Optional collapsible tree for group attributes (Zarr and others)         |
-| **Settings**  | New `scientificDataViewer.nestedAttributesView` (boolean, default false) |
+| Area          | Change                                                                  |
+| ------------- | ----------------------------------------------------------------------- |
+| **UI**        | Collapsible tree for group attributes (Zarr and others), on by default  |
+| **Settings**  | New `scientificDataViewer.nestedAttributesView` (boolean, default true) |
 | **Test data** | New Zarr sample with deeply nested `.zattrs` for Issue #120              |
 | **Config**    | Webview receives a plain config object including `nestedAttributesView`  |
 | **Docs**      | Release notes, CHANGELOG, README updated; xarray upstream noted          |

--- a/docs/RELEASE_NOTES_0.10.0.md
+++ b/docs/RELEASE_NOTES_0.10.0.md
@@ -1,0 +1,55 @@
+# Scientific Data Viewer v0.10.0 Release Notes
+
+**TL;DR** — **Collapsible nested attributes view** (Issue #120): optional tree view for Zarr (and other formats) that store attributes as nested JSON. Enable via **Nested Attributes View** setting (off by default). Test data script now generates a Zarr store with deeply nested `.zattrs` for QA. Version bump to **0.10.0**.
+
+## Collapsible nested attributes view (Issue #120)
+
+Formats such as **Zarr** store group attributes in JSON (e.g. `.zattrs`). The previous UI showed only one level of attributes; nested structures were hard to read. This release adds an optional **tree view** so you can expand and collapse the full attribute hierarchy.
+
+### Feature flag (opt-in)
+
+- **Setting:** `scientificDataViewer.nestedAttributesView`
+- **Default:** `false` (opt-in for initial release)
+- **Location:** VS Code Settings → Scientific Data Viewer (or `.vscode/settings.json`)
+
+When enabled, the **Attributes** section for each group is rendered as an expandable/collapsible tree instead of a flat list. Nested objects and arrays are shown as nodes you can open to inspect deeper levels. This is especially useful for Zarr datasets with complex metadata (e.g. CF conventions, producer-specific `.zattrs`).
+
+### Use cases
+
+- **Zarr users:** Open a Zarr dataset with complex `.zattrs` and expand the tree to see the full nested structure without copying JSON elsewhere.
+- **Metadata inspection:** Browse the attribute tree in-context while viewing dimensions and variables.
+- **Gradual rollout:** The feature is off by default so it can be validated with a subset of users before potentially becoming the default.
+
+### Technical notes
+
+- The backend already exposes nested attribute structures (e.g. from xarray/Zarr); the change is in the SDV webview, which now renders them as a tree when the flag is on.
+- For very large attribute trees, only visible nodes are expanded; consider lazy expansion or virtualization in a future release if needed.
+- Tree styling uses VS Code theme variables and follows the same patterns as other collapsible sections (e.g. `details`/`summary`).
+
+## Test data: Zarr with deeply nested attributes
+
+The sample data script (`python/create_sample_data.py`) now creates a Zarr store with **extremely nested** group attributes for testing this feature:
+
+- **File:** `sample_zarr_deeply_nested_attrs.zarr`
+- **Content:** Minimal array plus root `.zattrs` with 5–10 levels of nested dicts and mixed arrays/objects.
+- **Purpose:** Regression testing and manual QA of the collapsible nested-attributes UI.
+
+Run the script (e.g. from the repo root) to generate all sample files, including this one. Open the generated Zarr in the viewer and enable **Nested Attributes View** to see the tree.
+
+## xarray and nested attributes (upstream)
+
+The current xarray and SDV text/HTML representations show attributes in a limited way; nested structures are not always easy to read. Improving the representation of nested attributes in xarray’s APIs or built-in reprs would benefit both the library and downstream tools like SDV. Consider opening or supporting a feature request on the [xarray GitHub repository](https://github.com/pydata/xarray) if you need better first-class support for nested attributes in xarray itself. SDV’s collapsible tree view works with the nested structures that xarray already returns when reading Zarr (and similar) stores.
+
+## Upgrading
+
+After updating to 0.10.0, the nested attributes tree is **off by default**. To use it, enable **Nested Attributes View** in extension settings. No other breaking changes in this release.
+
+## Summary of changes
+
+| Area            | Change                                                                 |
+|-----------------|------------------------------------------------------------------------|
+| **UI**          | Optional collapsible tree for group attributes (Zarr and others)     |
+| **Settings**    | New `scientificDataViewer.nestedAttributesView` (boolean, default false) |
+| **Test data**   | New Zarr sample with deeply nested `.zattrs` for Issue #120            |
+| **Config**      | Webview receives a plain config object including `nestedAttributesView` |
+| **Docs**        | Release notes, CHANGELOG, README updated; xarray upstream noted       |

--- a/docs/RELEASE_NOTES_0.10.0.md
+++ b/docs/RELEASE_NOTES_0.10.0.md
@@ -50,6 +50,6 @@ After updating to 0.10.0, the nested attributes tree is **on by default**. You c
 | ------------- | ----------------------------------------------------------------------- |
 | **UI**        | Collapsible tree for group attributes (Zarr and others), on by default  |
 | **Settings**  | New `scientificDataViewer.nestedAttributesView` (boolean, default true) |
-| **Test data** | New Zarr sample with deeply nested `.zattrs` for Issue #120              |
-| **Config**    | Webview receives a plain config object including `nestedAttributesView`  |
-| **Docs**      | Release notes, CHANGELOG, README updated; xarray upstream noted          |
+| **Test data** | New Zarr sample with deeply nested `.zattrs` for Issue #120             |
+| **Config**    | Webview receives a plain config object including `nestedAttributesView` |
+| **Docs**      | Release notes, CHANGELOG, README updated; xarray upstream noted         |

--- a/docs/XARRAY_NESTED_ATTRIBUTES.md
+++ b/docs/XARRAY_NESTED_ATTRIBUTES.md
@@ -1,0 +1,26 @@
+# xarray and nested attributes
+
+This document records the Scientific Data Viewer’s need for better handling of **nested attributes** in scientific datasets, and how that relates to the [xarray](https://github.com/pydata/xarray) project.
+
+## Context
+
+Formats such as **Zarr** store group attributes in JSON (e.g. `.zattrs`). Those attributes can be deeply nested (objects and arrays). The current xarray APIs and built-in representations (e.g. HTML or text repr) typically expose attributes in a flat or single-level way, which makes it hard to inspect or document complex metadata in the IDE or in notebooks.
+
+## SDV approach (Issue #120)
+
+The Scientific Data Viewer addresses this on the **viewer side** by adding an optional **collapsible tree view** for group attributes (see [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)). When the user enables **Nested Attributes View**, the extension renders the full nested structure (as returned by xarray/Zarr) in an expandable/collapsible tree. No change to xarray is required for this.
+
+## Upstream (xarray)
+
+Improving the **representation of nested attributes** inside xarray itself (e.g. in `repr()`, HTML repr, or public APIs) would benefit:
+
+- Users who work in Jupyter or other environments that rely on xarray’s built-in repr
+- Downstream tools (including SDV) that might align with xarray’s representation
+- Consistency when the same dataset is opened in xarray and in SDV
+
+If you need first-class support for nested attributes in xarray’s APIs or reprs, consider opening or supporting a feature request on the xarray repository:
+
+- **xarray GitHub:** <https://github.com/pydata/xarray>
+- **xarray issue tracker:** <https://github.com/pydata/xarray/issues>
+
+At the time of writing (v0.10.0), SDV does not maintain an open xarray issue for this; the above is for reference and for anyone who wants to drive an upstream improvement.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "scientific-data-viewer",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "scientific-data-viewer",
-            "version": "0.9.0",
+            "version": "0.10.0",
             "dependencies": {
                 "axios": "^1.6.0",
                 "jsdom": "^27.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "scientific-data-viewer",
     "displayName": "Scientific Data Viewer",
     "description": "A VSCode extension for viewing scientific data files including NetCDF, Zarr, HDF5, GRIB, GeoTIFF, and more",
-    "version": "0.9.0",
+    "version": "0.10.0",
     "publisher": "eschalk0",
     "icon": "media/icon.png",
     "engines": {
@@ -529,6 +529,13 @@
                     "order": 1006,
                     "description": "Max character length for displayed small variable/coordinate values (truncation). Used when smallVariableBytes > 0.",
                     "markdownDescription": "Maximum character length for the string representation of small variable/coordinate values. Longer representations are truncated with \"...\". Only used when **smallVariableBytes** is greater than 0."
+                },
+                "scientificDataViewer.nestedAttributesView": {
+                    "type": "boolean",
+                    "default": true,
+                    "order": 1007,
+                    "description": "Show attributes as a collapsible tree (for Zarr and other formats with nested JSON attributes). On by default.",
+                    "markdownDescription": "When enabled, group attributes are shown as an **expandable/collapsible tree** instead of a flat list. Useful for Zarr (and similar formats) where attributes are stored as nested JSON (e.g. `.zattrs`). **On by default.** See [Issue #120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)."
                 }
             }
         }

--- a/python/create_sample_data.py
+++ b/python/create_sample_data.py
@@ -659,6 +659,84 @@ def create_sample_zarr_with_nested_groups_from_zarr():
     return output_file
 
 
+def create_sample_zarr_deeply_nested_attributes():
+    """Create a Zarr store with extremely nested group attributes for testing Issue #120.
+
+    Zarr stores attributes in JSON (.zattrs). This produces a store with 5–10 levels
+    of nested dicts so the collapsible nested-attributes view can be tested and
+    regressions avoided. Uses xarray to write the store so dimension metadata
+    (dimension_names / _ARRAY_DIMENSIONS) is correct for reopening with xarray.
+    """
+    output_file = "sample_zarr_deeply_nested_attrs.zarr"
+
+    if os.path.exists(output_file):
+        print(f"📦 Zarr file {output_file} already exists. Skipping creation.")
+        print("  🔄 To regenerate, please delete the existing directory first.")
+        return output_file
+
+    print(
+        "🌊 Creating sample Zarr file with deeply nested group attributes (Issue #120)..."
+    )
+
+    # Deeply nested attributes (10 levels) – typical of complex .zattrs from producers
+    nested_attrs = {
+        "title": "Zarr with deeply nested attributes (Issue #120)",
+        "description": "Test data for collapsible nested attributes view in SDV",
+        "deep": {
+            "level1": {
+                "level2": {
+                    "level3": {
+                        "level4": {
+                            "level5": {
+                                "level6": {
+                                    "level7": {
+                                        "level8": {
+                                            "level9": {
+                                                "level10": "leaf_value",
+                                                "count": 42,
+                                            },
+                                            "name": "deep_node_8",
+                                        },
+                                        "name": "deep_node_7",
+                                    },
+                                    "name": "deep_node_6",
+                                },
+                                "name": "deep_node_5",
+                            },
+                            "name": "deep_node_4",
+                        },
+                        "name": "deep_node_3",
+                    },
+                    "name": "deep_node_2",
+                },
+                "name": "deep_node_1",
+            },
+            "summary": "Use Nested Attributes View setting to expand this tree",
+        },
+        "metadata": {
+            "creator": {"name": "SDV test", "version": "0.10.0"},
+            "nested_list": [1, 2, {"a": "b", "c": [10, 20]}, "four"],
+            "sections": {
+                "instruments": {"sensor": "thermometer", "accuracy": 0.1},
+                "quality": {"flags": [0, 1, 2], "meaning": "good questionable bad"},
+            },
+        },
+    }
+
+    # Create with xarray so dimension metadata is written correctly (works with zarr v2 and v3)
+    ds = xr.Dataset(
+        {"value": (["x"], [1.0, 2.0, 3.0])},
+        coords={"x": [0, 1, 2]},
+        attrs=nested_attrs,
+    )
+    ds.to_zarr(output_file, mode="w")
+
+    print(
+        f"✅ Created {output_file} with deeply nested .zattrs for nested-attributes UI testing"
+    )
+    return output_file
+
+
 def create_sample_hdf5():
     """Create a sample HDF5 file with satellite data."""
     output_file = "sample_data.h5"
@@ -5419,6 +5497,14 @@ def main(do_create_disposable_files: bool = False):
             created_files.append((inherited_coords_zarr_file, "Zarr Inherited Coords"))
         else:
             skipped_files.append("Zarr Inherited Coords (zarr or xarray not available)")
+
+        deeply_nested_attrs_zarr_file = create_sample_zarr_deeply_nested_attributes()
+        if deeply_nested_attrs_zarr_file:
+            created_files.append(
+                (deeply_nested_attrs_zarr_file, "Zarr deeply nested attrs (Issue #120)")
+            )
+        else:
+            skipped_files.append("Zarr deeply nested attrs (zarr not available)")
 
         print("\n📄 Creating file with spaces in name...")
         spaces_file = create_sample_file_with_spaces()

--- a/src/common/config.ts
+++ b/src/common/config.ts
@@ -47,6 +47,7 @@ const GROUP_TIME_CONTROLS = 'groupTimeControls';
 const GROUP_DIMENSION_SLICES = 'groupDimensionSlices';
 const SMALL_VARIABLE_BYTES = 'smallVariableBytes';
 const SMALL_VALUE_DISPLAY_MAX_LEN = 'smallValueDisplayMaxLen';
+const NESTED_ATTRIBUTES_VIEW = 'nestedAttributesView';
 
 // Default values
 const DEFAULT_MAX_FILE_SIZE = 1000000000000;
@@ -65,6 +66,7 @@ const DEFAULT_GROUP_TIME_CONTROLS = false;
 const DEFAULT_GROUP_DIMENSION_SLICES = true;
 const DEFAULT_SMALL_VARIABLE_BYTES = 1000;
 const DEFAULT_SMALL_VALUE_DISPLAY_MAX_LEN = 500;
+const DEFAULT_NESTED_ATTRIBUTES_VIEW = true;
 
 // Configuration functions
 export function getUseExtensionOwnEnvironmentConfigFullKey(): string {
@@ -179,6 +181,27 @@ export function getSmallValueDisplayMaxLen(): number {
         SMALL_VALUE_DISPLAY_MAX_LEN,
         DEFAULT_SMALL_VALUE_DISPLAY_MAX_LEN,
     );
+}
+
+export function getNestedAttributesView(): boolean {
+    return getWorkspaceConfig().get<boolean>(
+        NESTED_ATTRIBUTES_VIEW,
+        DEFAULT_NESTED_ATTRIBUTES_VIEW,
+    );
+}
+
+/**
+ * Plain object of extension config flags for the webview (feature flags and display options).
+ * Use this instead of passing WorkspaceConfiguration so the webview receives a predictable object.
+ */
+export function getExtensionConfigForWebview(): Record<string, unknown> {
+    return {
+        globalTimeControls: getGlobalTimeControls(),
+        globalDimensionSlices: getGlobalDimensionSlices(),
+        groupTimeControls: getGroupTimeControls(),
+        groupDimensionSlices: getGroupDimensionSlices(),
+        nestedAttributesView: getNestedAttributesView(),
+    };
 }
 
 export async function updateUseExtensionOwnEnvironment(

--- a/src/panel/UIController.ts
+++ b/src/panel/UIController.ts
@@ -14,7 +14,7 @@ import { showErrorMessage } from '../common/vscodeutils';
 import {
     getDevMode,
     getMaxSize,
-    getWorkspaceConfig,
+    getExtensionConfigForWebview,
     getWebviewExportTheme,
     getConvertBandsToVariables,
 } from '../common/config';
@@ -636,8 +636,7 @@ export class UIController {
 
         return (
             this.errorBoundary.wrapAsync(async () => {
-                const config = getWorkspaceConfig();
-                return config;
+                return getExtensionConfigForWebview();
             }, context) || {}
         );
     }

--- a/src/panel/webview/styles.css
+++ b/src/panel/webview/styles.css
@@ -410,6 +410,36 @@ select:focus {
     flex: 1;
 }
 
+/* Collapsible nested attributes tree (Issue #120) */
+.attributes-tree-node {
+    margin-left: 0.75rem;
+    margin-top: 2px;
+}
+.attributes-tree-node details {
+    margin-left: 0.5rem;
+}
+.attribute-tree-summary {
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+.attribute-tree-summary::-webkit-details-marker {
+    display: none;
+}
+.attribute-tree-summary::before {
+    content: '▸ ';
+    display: inline-block;
+    width: 1em;
+}
+.attributes-tree-node[open] > .attribute-tree-summary::before {
+    content: '▾ ';
+}
+.attributes-tree-children {
+    margin-left: 0.5rem;
+    border-left: 1px solid var(--vscode-panel-border);
+    padding-left: 0.5rem;
+}
+
 .muted-text {
     color: var(--vscode-descriptionForeground);
 }

--- a/src/panel/webview/webview-script.js
+++ b/src/panel/webview/webview-script.js
@@ -1154,7 +1154,7 @@ function renderAttributesTree(attrsObj, groupName, idParts) {
                             typeof item === 'string'
                                 ? item
                                 : JSON.stringify(item);
-                            return /*html*/ `<div class="attribute-item"><span class="attribute-value muted-text">${escapeHtml(str)}</span></div>`;
+                        return /*html*/ `<div class="attribute-item"><span class="attribute-value muted-text">${escapeHtml(str)}</span></div>`;
                     })
                     .join('');
                 return /*html*/ `
@@ -1166,9 +1166,7 @@ function renderAttributesTree(attrsObj, groupName, idParts) {
             const valueStr =
                 typeof value === 'string' ? value : JSON.stringify(value);
             const displayStr =
-                valueStr.length > 500
-                    ? valueStr.slice(0, 500) + '…'
-                    : valueStr;
+                valueStr.length > 500 ? valueStr.slice(0, 500) + '…' : valueStr;
             return /*html*/ `
                 <div class="attribute-item" id="${leafId}">
                     <span class="attribute-name" title="${safeKey}">${safeKey}</span>

--- a/src/panel/webview/webview-script.js
+++ b/src/panel/webview/webview-script.js
@@ -693,12 +693,13 @@ function displayDataInfo(data, filePath, extensionConfig) {
         return;
     }
 
-    // Feature flags (default true when config not available)
+    // Feature flags (default true when config not available; nestedAttributesView default true)
     const config = extensionConfig || {};
     const globalTimeControls = config.globalTimeControls !== false;
     const globalDimensionSlices = config.globalDimensionSlices !== false;
     const groupTimeControls = config.groupTimeControls !== false;
     const groupDimensionSlices = config.groupDimensionSlices !== false;
+    const nestedAttributesView = config.nestedAttributesView !== false;
 
     // Store current file path for plot operations
     globalState.currentDatasetFilePath = filePath;
@@ -732,6 +733,7 @@ function displayDataInfo(data, filePath, extensionConfig) {
                 renderGroup(data, groupName, {
                     groupTimeControls,
                     groupDimensionSlices,
+                    nestedAttributesView,
                     isFirstRootGroup: index === 0,
                 }),
             )
@@ -805,6 +807,7 @@ function renderGroup(data, groupName, flags) {
     const groupTimeControls = (flags && flags.groupTimeControls) !== false;
     const groupDimensionSlices =
         (flags && flags.groupDimensionSlices) !== false;
+    const nestedAttributesView = (flags && flags.nestedAttributesView) === true;
 
     // Add dimensions for group
     const dimensions = data.dimensions_flattened[groupName];
@@ -827,15 +830,25 @@ function renderGroup(data, groupName, flags) {
             ? renderGroupDataVariables(variables, groupName)
             : /*html*/ `<p class="muted-text">No variables found in this group.</p>`;
 
-    // Add attributes for group
+    // Add attributes for group (flat list or collapsible tree when nestedAttributesView is on)
     const attributes = data.attributes_flattened[groupName];
     const attributesHtml =
         attributes && Object.keys(attributes).length > 0
-            ? Object.entries(attributes)
-                  .map(([attrName, value]) => {
-                      return renderGroupAttributes(groupName, attrName, value);
-                  })
-                  .join('')
+            ? nestedAttributesView
+                ? renderAttributesTree(attributes, groupName, [
+                      'data-group',
+                      groupName,
+                      'attributes',
+                  ])
+                : Object.entries(attributes)
+                      .map(([attrName, value]) => {
+                          return renderGroupAttributes(
+                              groupName,
+                              attrName,
+                              value,
+                          );
+                      })
+                      .join('')
             : /*html*/ `<p class="muted-text">No attributes found in this group.</p>`;
 
     const groupPlotControlsHtml =
@@ -1080,6 +1093,90 @@ function renderGroupDataVariables(variables, groupName) {
             return renderDataVariable(variable, groupName);
         })
         .join('');
+}
+
+/**
+ * Renders a nested attributes object as a collapsible tree (for Zarr .zattrs and similar).
+ * Used when nestedAttributesView feature flag is on.
+ * @param {Record<string, any>} attrsObj - Attributes object (may contain nested objects/arrays)
+ * @param {string} groupName - Group name for id generation
+ * @param {string[]} idParts - Base id parts for joinId (e.g. ['data-group', groupName, 'attributes'])
+ * @returns {string} HTML string
+ */
+function renderAttributesTree(attrsObj, groupName, idParts) {
+    if (!attrsObj || typeof attrsObj !== 'object') {
+        return '';
+    }
+    const entries = Object.entries(attrsObj);
+    if (entries.length === 0) {
+        return /*html*/ `<p class="muted-text">No attributes.</p>`;
+    }
+    return entries
+        .map(([key, value]) => {
+            const safeKey = escapeHtml(String(key));
+            const leafId = joinId([...idParts, 'attr', safeKey]);
+            const isNested =
+                value !== null &&
+                typeof value === 'object' &&
+                !(value instanceof Date) &&
+                !(value instanceof RegExp);
+            if (isNested && !Array.isArray(value)) {
+                const childIdParts = [...idParts, 'attr', safeKey];
+                const innerHtml = renderAttributesTree(
+                    value,
+                    groupName,
+                    childIdParts,
+                );
+                return /*html*/ `
+                    <details class="attributes-tree-node" id="${joinId(childIdParts)}">
+                        <summary class="attribute-tree-summary"><span class="attribute-name">${safeKey}</span></summary>
+                        <div class="attributes-tree-children">${innerHtml}</div>
+                    </details>`;
+            }
+            if (isNested && Array.isArray(value)) {
+                const arrId = joinId([...idParts, 'attr', safeKey]);
+                const items = value
+                    .map((item, i) => {
+                        if (
+                            item !== null &&
+                            typeof item === 'object' &&
+                            !Array.isArray(item) &&
+                            !(item instanceof Date)
+                        ) {
+                            const inner = renderAttributesTree(
+                                item,
+                                groupName,
+                                [...idParts, 'attr', safeKey, String(i)],
+                            );
+                            return /*html*/ `<details class="attributes-tree-node"><summary class="attribute-tree-summary">[${i}]</summary><div class="attributes-tree-children">${inner}</div></details>`;
+                        }
+                        const str =
+                            typeof item === 'string'
+                                ? item
+                                : JSON.stringify(item);
+                            return /*html*/ `<div class="attribute-item"><span class="attribute-value muted-text">${escapeHtml(str)}</span></div>`;
+                    })
+                    .join('');
+                return /*html*/ `
+                    <details class="attributes-tree-node" id="${arrId}">
+                        <summary class="attribute-tree-summary"><span class="attribute-name">${safeKey}</span> <span class="muted-text">(${value.length} items)</span></summary>
+                        <div class="attributes-tree-children">${items}</div>
+                    </details>`;
+            }
+            const valueStr =
+                typeof value === 'string' ? value : JSON.stringify(value);
+            const displayStr =
+                valueStr.length > 500
+                    ? valueStr.slice(0, 500) + '…'
+                    : valueStr;
+            return /*html*/ `
+                <div class="attribute-item" id="${leafId}">
+                    <span class="attribute-name" title="${safeKey}">${safeKey}</span>
+                    <span> : </span>
+                    <span class="attribute-value muted-text" title="${escapeHtml(valueStr)}">${escapeHtml(displayStr)}</span>
+                </div>`;
+        })
+        .join('\n');
 }
 
 function renderGroupAttributes(groupName, attrName, value) {

--- a/src/panel/webview/webview-script.js
+++ b/src/panel/webview/webview-script.js
@@ -22,6 +22,9 @@ const SUPPORTED_EXTENSIONS_HARDOCDED = [
     '.jpeg2000',
     // '.safe',
 ];
+
+const MAX_ATTR_DISPLAY_STR_LENGTH = 999999;
+
 class WebviewMessageBus {
     constructor(vscode) {
         this.vscode = vscode;
@@ -1166,7 +1169,9 @@ function renderAttributesTree(attrsObj, groupName, idParts) {
             const valueStr =
                 typeof value === 'string' ? value : JSON.stringify(value);
             const displayStr =
-                valueStr.length > 500 ? valueStr.slice(0, 500) + '…' : valueStr;
+                valueStr.length > MAX_ATTR_DISPLAY_STR_LENGTH
+                    ? valueStr.slice(0, MAX_ATTR_DISPLAY_STR_LENGTH) + '…'
+                    : valueStr;
             return /*html*/ `
                 <div class="attribute-item" id="${leafId}">
                     <span class="attribute-name" title="${safeKey}">${safeKey}</span>

--- a/test/suite/config.test.ts
+++ b/test/suite/config.test.ts
@@ -6,6 +6,8 @@ import {
     getGroupDimensionSlices,
     getSmallVariableBytes,
     getSmallValueDisplayMaxLen,
+    getNestedAttributesView,
+    getExtensionConfigForWebview,
 } from '../../src/common/config';
 
 suite('Config Test Suite', () => {
@@ -37,5 +39,20 @@ suite('Config Test Suite', () => {
     test('getSmallValueDisplayMaxLen returns a number', () => {
         const value = getSmallValueDisplayMaxLen();
         assert.strictEqual(typeof value, 'number');
+    });
+
+    test('getNestedAttributesView returns a boolean', () => {
+        const value = getNestedAttributesView();
+        assert.strictEqual(typeof value, 'boolean');
+    });
+
+    test('getExtensionConfigForWebview returns object with expected keys', () => {
+        const config = getExtensionConfigForWebview();
+        assert.strictEqual(typeof config, 'object');
+        assert.strictEqual(typeof config.globalTimeControls, 'boolean');
+        assert.strictEqual(typeof config.globalDimensionSlices, 'boolean');
+        assert.strictEqual(typeof config.groupTimeControls, 'boolean');
+        assert.strictEqual(typeof config.groupDimensionSlices, 'boolean');
+        assert.strictEqual(typeof config.nestedAttributesView, 'boolean');
     });
 });


### PR DESCRIPTION
# Pull Request: v0.10.0 — Collapsible nested attributes view

## Summary

**Release:** v0.10.0  
**Feature:** Collapsible nested attributes view (single feature release)  
**Closes:** [#120](https://github.com/etienneschalk/scientific-data-viewer/issues/120)

Formats such as **Zarr** store group attributes in JSON (e.g. `.zattrs`). The previous UI showed only one level of attributes; nested structures were hard to read. This PR adds a **collapsible tree view** for group attributes so users can expand and collapse the full hierarchy. The feature is **on by default** and can be turned off in settings to use the flat list.

---

## What changed

### User-facing

- **Attributes section:** For each group (e.g. root `/` or Zarr subgroups), the **Attributes** block is now rendered as an **expandable/collapsible tree** when the feature is enabled. Nested objects and arrays appear as nodes that can be opened to inspect deeper levels.
- **Setting:** New `scientificDataViewer.nestedAttributesView` (boolean, **default `true`**). Set to `false` to use the previous flat attribute list (opt-out).
- **Test data:** The sample data script creates `sample_zarr_deeply_nested_attrs.zarr` with 5–10 levels of nested `.zattrs` for manual and regression testing.

### Code

| Area | Changes |
|------|---------|
| **Config** | `getNestedAttributesView()`, `getExtensionConfigForWebview()`; webview receives a plain config object with all feature flags. |
| **Webview** | `renderAttributesTree()` for nested objects/arrays; `renderGroup()` uses tree or flat list based on `nestedAttributesView`. |
| **Styles** | `.attributes-tree-node`, `.attribute-tree-summary`, `.attributes-tree-children` for tree layout and expand/collapse. |
| **Sample data** | `create_sample_zarr_deeply_nested_attributes()` builds the Zarr store via `xarray.Dataset.to_zarr()` so metadata is valid for reopening. |
| **Docs** | Release notes (0.10.0), README, CHANGELOG, and `docs/XARRAY_NESTED_ATTRIBUTES.md` (upstream note). |

---

## How to test

1. **Build / run** the extension (e.g. F5 in VS Code).
2. **Open a Zarr** with nested attributes (e.g. run `python create_sample_data.py` and open `sample_zarr_deeply_nested_attrs.zarr`).
3. **Confirm** the Attributes section for the root group shows a tree (expand/collapse nodes). Default is tree view.
4. **Opt-out:** Set `scientificDataViewer.nestedAttributesView` to `false`, reload, and confirm attributes are shown as a flat list again.

---

## Checklist

- [x] Feature implemented (collapsible tree for nested attributes)
- [x] Setting added with default `true` (opt-out)
- [x] Test data script creates Zarr with deeply nested `.zattrs`
- [x] Release notes, README, and CHANGELOG updated
- [x] Config tests for new getters
- [x] Version set to 0.10.0 in `package.json`

---

## Documentation

- **Release notes:** [docs/RELEASE_NOTES_0.10.0.md](./RELEASE_NOTES_0.10.0.md)
- **xarray upstream note:** [docs/XARRAY_NESTED_ATTRIBUTES.md](./XARRAY_NESTED_ATTRIBUTES.md)
