### PR TITLE
fix(plot): strip add_legend on generic DataArray.plot unless hue (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
 
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [0.11.1] - 2026-04-07
+
+### Fixed
+
+- **`add_legend` on generic `DataArray.plot`**: When the UI or CLI enabled `add_legend` and parameters such as **`col_wrap`** forced the user-provided **`slices_only`** path, kwargs were passed to xarray’s generic `.plot()`, which can route to **`pcolormesh`** (`QuadMesh`). Matplotlib rejects **`add_legend`** there ([issue #134](https://github.com/etienneschalk/scientific-data-viewer/issues/134)). The dispatcher now strips **`add_legend`** unless **`hue`** is set, matching the existing **`plot.imshow`** guard.
+  - **Files**: `python/get_data_info.py`
+- **Non-regression**: Case **25** in `python/non_regression_test_plot.py` covers **`col_wrap` + `add_legend`** on a **3D** subset without **`cmap`**.
+
 ## [0.11.0] - 2026-03-24
 
 ### Breaking

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extension to explore the metadata of scientific data files within your IDE, i
 
 <div align="center">
 
-**Current Version: v0.11.0** • [Release Notes](./docs/RELEASE_NOTES_0.11.0.md)
+**Current Version: v0.11.1** • [Changelog](./CHANGELOG.md) • [v0.11.0 release notes](./docs/RELEASE_NOTES_0.11.0.md)
 
 Available on:
 [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=eschalk0.scientific-data-viewer) • [Open VSX Registry](https://open-vsx.org/extension/eschalk0/scientific-data-viewer)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4360,9 +4360,9 @@
             }
         },
         "node_modules/lodash": {
-            "version": "4.17.23",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-            "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+            "version": "4.18.1",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
             "dev": true,
             "license": "MIT"
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "scientific-data-viewer",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "scientific-data-viewer",
-            "version": "0.11.0",
+            "version": "0.11.1",
             "dependencies": {
                 "axios": "^1.6.0",
                 "jsdom": "^27.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "scientific-data-viewer",
     "displayName": "Scientific Data Viewer",
     "description": "A VSCode extension for viewing scientific data files including NetCDF, Zarr, HDF5, GRIB, GeoTIFF, and more",
-    "version": "0.11.0",
+    "version": "0.11.1",
     "publisher": "eschalk0",
     "icon": "media/icon.png",
     "engines": {

--- a/python/get_data_info.py
+++ b/python/get_data_info.py
@@ -949,13 +949,18 @@ def _log_plot_route(route: str) -> None:
 
 
 def _strip_add_legend_unless_hue(plot_kwargs: dict[str, Any]) -> dict[str, Any]:
-    """xarray ``plot.imshow`` does not accept ``add_legend`` without ``hue`` (can raise)."""
-    if plot_kwargs.get("add_legend") and "hue" not in plot_kwargs:
-        out = dict(plot_kwargs)
-        out.pop("add_legend", None)
-        logger.info("add_legend omitted for plot.imshow without hue=")
-        return out
-    return plot_kwargs
+    """Omit ``add_legend`` when ``hue`` is absent.
+
+    xarray's generic ``DataArray.plot`` may route to ``pcolormesh`` (``QuadMesh``);
+    those artists do not accept ``add_legend``. The same applies to ``plot.imshow``
+    without ``hue``. See https://github.com/etienneschalk/scientific-data-viewer/issues/134
+    """
+    if "hue" in plot_kwargs or "add_legend" not in plot_kwargs:
+        return plot_kwargs
+    out = dict(plot_kwargs)
+    out.pop("add_legend", None)
+    logger.info("add_legend omitted for plot without hue=")
+    return out
 
 
 @dataclass(frozen=True)
@@ -1062,7 +1067,7 @@ class XarrayPlotDispatcher:
 
     def plot(self, dataarray: xr.DataArray, route: str, **kwargs: Any) -> None:
         if kwargs:
-            dataarray.plot(**kwargs)
+            dataarray.plot(**_strip_add_legend_unless_hue(kwargs))
         else:
             dataarray.plot()
         _log_plot_route(route)
@@ -1611,8 +1616,10 @@ def create_plot(
     add_colorbar : bool, optional
         Whether to draw a colorbar for scalar-mappable plots (default True). Ignored for histograms.
     add_legend : bool, optional
-        Whether to add a legend when xarray supports it (e.g. ``hue``); ignored for ``plot.imshow``
-        without ``hue`` (by default False).
+        Whether to add a legend when xarray supports it (e.g. ``hue``). Omitted on generic
+        ``DataArray.plot`` and ``plot.imshow`` when ``hue`` is not set, so kwargs are not
+        forwarded to matplotlib artists that reject ``add_legend`` (e.g. ``QuadMesh``).
+        Default False.
 
     Returns
     -------

--- a/python/non_regression_test_plot.py
+++ b/python/non_regression_test_plot.py
@@ -3,7 +3,7 @@
 Non-regression plot checks for create_plot (Issue #117 workflows).
 
 Exercises Issue #117 scenarios (cases 00-06), combinations (10-18), and
-v0.11+ plot controls (20-24: vmin/vmax maps, colorbar, legend) on the same
+v0.11+ plot controls (20-25: vmin/vmax maps, colorbar, legend, issue #134) on the same
 sample file. See:
 https://github.com/etienneschalk/scientific-data-viewer/issues/117#issuecomment-4025666878
 
@@ -12,7 +12,7 @@ after ``isel(rlat=slice(200,500), rlon=slice(2000,2250))`` on the original grid)
 
 By default, PNG outputs go under
 ``sample-data/non_regression_test_plot/v<version>/`` where ``<version>`` is read
-from the repository ``package.json`` (e.g. ``v0.11.0``). Pass ``--out-dir`` to
+from the repository ``package.json`` (e.g. ``v0.11.1``). Pass ``--out-dir`` to
 override. ``setup.sh`` runs this after ``create_sample_data.py`` for visual checks.
 Also writes ``summary.md`` next to ``summary.txt`` (markdown with embedded PNGs).
 
@@ -77,7 +77,7 @@ def _merge_slices(base: dict[str, str], extra: dict[str, Any] | None) -> dict[st
 
 @dataclass(frozen=True)
 class PlotCase:
-    """One non-regression case: core (00-06), combos (10-18), or vlim/legend (20-24)."""
+    """One non-regression case: core (00-06), combos (10-18), or vlim/legend (20-25)."""
 
     slug: str
     doc: str
@@ -324,7 +324,7 @@ def _plot_cases(full_grid: bool) -> list[PlotCase]:
 
 
 def _cases_vmin_vmax_colorbar_legend(full_grid: bool) -> list[PlotCase]:
-    """Cases 20+: vmin, vmax, add_colorbar, add_legend (create_plot v0.11+)."""
+    """Cases 20+: vmin, vmax, add_colorbar, add_legend (create_plot v0.11+); 25 = issue #134."""
     if full_grid:
         b = _FULL_GRID_BASE_SLICES
         return [
@@ -403,6 +403,23 @@ def _cases_vmin_vmax_colorbar_legend(full_grid: bool) -> list[PlotCase]:
                 cmap="plasma",
                 vmin=1.0,
             ),
+            PlotCase(
+                slug="25_add_legend_col_wrap_3d",
+                doc=(
+                    "Issue #134: col_wrap forces user_provided + slices_only; 3D subcube "
+                    "without cmap uses DataArray.plot — add_legend must not reach QuadMesh"
+                ),
+                title="add_legend + col_wrap on 3D (generic .plot path)",
+                xarray_code=(
+                    "sub = ds.isel(time=slice(0, 4), rlat=slice(200, 500), "
+                    "rlon=slice(2000, 2250))['hs']\n"
+                    "plt.figure()\n"
+                    "sub.plot(col_wrap=2, add_legend=True)"
+                ),
+                dimension_slices=_merge_slices(b, {"time": "0:4"}),
+                col_wrap=2,
+                add_legend=True,
+            ),
         ]
 
     return [
@@ -470,6 +487,22 @@ def _cases_vmin_vmax_colorbar_legend(full_grid: bool) -> list[PlotCase]:
             dimension_slices={"time": 0},
             cmap="plasma",
             vmin=1.0,
+        ),
+        PlotCase(
+            slug="25_add_legend_col_wrap_3d",
+            doc=(
+                "Issue #134: col_wrap + add_legend on 3D slice without cmap "
+                "(generic DataArray.plot must not pass add_legend to QuadMesh)"
+            ),
+            title="add_legend + col_wrap on 3D (generic .plot path)",
+            xarray_code=(
+                "plt.figure()\n"
+                "hs.isel(time=slice(0, 4), rlat=slice(0, 80), "
+                "rlon=slice(0, 80)).plot(col_wrap=2, add_legend=True)"
+            ),
+            dimension_slices={"time": "0:4", "rlat": "0:80", "rlon": "0:80"},
+            col_wrap=2,
+            add_legend=True,
         ),
     ]
 
@@ -791,7 +824,8 @@ def _write_summary_md(
         f"Case **00** is the baseline `hs.plot()` with no extra UI/plot kwargs; "
         f"**01-06** follow the [issue comment]({ISSUE_117_COMMENT_URL}); "
         "**10-18** add mixed `create_plot` options (cmap, robust, layout, facets, "
-        "axes); **20-24** cover `vmin`/`vmax`, `add_colorbar`, `add_legend`.\n\n",
+        "axes); **20-25** cover `vmin`/`vmax`, `add_colorbar`, `add_legend` "
+        "(**25** = issue #134).\n\n",
         "## Run parameters\n\n",
         f"- **Data file:** `{data_path}`\n",
         f"- **Variable path:** `{variable_path}`\n",


### PR DESCRIPTION
Xarray routes generic .plot() to pcolormesh/QuadMesh for many 2D/3D cases; matplotlib rejects add_legend. Apply the same guard used for plot.imshow in XarrayPlotDispatcher.plot when col_wrap or other UI params force the user-provided slices_only path.

Bump extension to v0.11.1 (patch). Add non-regression case 25.