### PR TITLE
Release v0.11.2: NetCDF decode_cf fallback (#136) and attribute HTML escaping (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
 
 <!-- and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). -->
 
+## [0.11.2] - 2026-06-18
+
+### Added
+
+- **Issue #136**: Degraded mode when CF time decoding fails. `open_datatree` / `open_dataset` first use `decode_cf=True`; on `unable to decode time units`, the extension retries with `decode_cf=False` so NetCDF files with invalid datetime `units` still open.
+  - **Files**: `python/get_data_info.py`, `src/panel/webview/webview-script.js`, `src/types.ts`
+  - **UI**: File Information shows `Mode: degraded (decode_cf=False)` when the fallback was used.
+  - **Sample data**: `python/create_sample_data.py` adds `sample-data/broken_datetime_variable.nc` for manual testing.
+
 ## [0.11.1] - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to the Scientific Data Viewer VSCode extension will be docum
   - **Files**: `python/get_data_info.py`, `src/panel/webview/webview-script.js`, `src/types.ts`
   - **UI**: File Information shows `Mode: degraded (decode_cf=False)` when the fallback was used.
   - **Sample data**: `python/create_sample_data.py` adds `sample-data/broken_datetime_variable.nc` for manual testing.
+- **Issue #137**: Escape HTML in flat attribute displays (`renderGroupAttributes`, `renderVariableAttributes`) via existing `escapeHtml()` so values such as compound-dtype `__xarray_encoding.dtype` strings (with `<i4`, `<f4`, etc.) are not truncated by the browser.
+  - **Sample data**: `sample-data/compound_dtype_variable.nc` (NumPy structured-array pets example).
+  - **Files**: `src/panel/webview/webview-script.js`, `python/create_sample_data.py`, `python/test_compound_dtype_sample.py`
 
 ## [0.11.1] - 2026-04-07
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An extension to explore the metadata of scientific data files within your IDE, i
 
 <div align="center">
 
-**Current Version: v0.11.1** • [Changelog](./CHANGELOG.md) • [v0.11.0 release notes](./docs/RELEASE_NOTES_0.11.0.md)
+**Current Version: v0.11.2** • [Changelog](./CHANGELOG.md) • [v0.11.2 release notes](./docs/RELEASE_NOTES_0.11.2.md)
 
 Available on:
 [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=eschalk0.scientific-data-viewer) • [Open VSX Registry](https://open-vsx.org/extension/eschalk0/scientific-data-viewer)

--- a/docs/Current State of the project - April 2026.md
+++ b/docs/Current State of the project - April 2026.md
@@ -1,0 +1,145 @@
+# Current State of the project - April 2026
+
+This note is a **high-level map** of the Scientific Data Viewer VS Code extension as of April 2026. Much of the implementation predates recent refactors: the extension host side mixes orchestration, I/O, and UI wiring, while the webview carries a very large client script. Treat this document as an **onboarding aid**, not a specification.
+
+---
+
+## What the extension does
+
+The extension opens scientific file formats (NetCDF, HDF5, Zarr, GRIB, GeoTIFF, JPEG 2000, and related extensions) in a **webview-based viewer**. It uses a **Python toolchain** (typically **xarray** and format-specific backends) to introspect datasets and render plots. Users can open files via **custom editors** registered in `package.json`, or via **commands** that create standalone `WebviewPanel`s.
+
+---
+
+## Entry point: `extension.ts`
+
+`activate` is the single authoritative bootstrap. `deactivate` tears down long-lived resources.
+
+### Activation sequence (Mermaid)
+
+The diagram below is a simplified ordering; some steps enqueue async work (for example, listening to the official Python extension) that finishes shortly after activation continues.
+
+```mermaid
+flowchart TD
+    A["activate(context)"] --> B["setPackageJson(...) from extension context"]
+    B --> C["Logger.initialize()"]
+    C --> D["ErrorBoundary: register global handler → Logger + window.showErrorMessage"]
+    D --> E["Build webview options + icon path"]
+    E --> F["createStatusBarItem (Python interpreter; hidden until updated)"]
+    F --> G["ExtensionVirtualEnvironmentManager(globalStorage)"]
+    G --> H["ExtensionVirtualEnvironmentManagerUI(env manager)"]
+    H --> I["PythonManager(env manager)"]
+    I --> J["DataProcessor.createInstance(pythonManager) singleton"]
+    J --> K["refreshPython: forceInitialize PythonManager, update status bar, refresh errored panels"]
+    K --> L["registerCustomEditorProviders → ScientificDataEditorProvider × view types"]
+    L --> M["OutlineProvider + createTreeView; DataViewerPanel.setOutlineProvider"]
+    M --> N["registerCommand for each contributed command"]
+    N --> O["workspace.onDidOpenTextDocument / onDidChangeConfiguration / onDidChangeWorkspaceFolders"]
+    O --> P["setupOfficialPythonExtensionChangeListeners (async → disposable pushed when ready)"]
+```
+
+### Two ways a viewer panel appears
+
+1. **Custom editor** — VS Code calls `ScientificDataEditorProvider.resolveCustomEditor`, which waits for `PythonManager.waitForInitialization()` (best effort), then `DataViewerPanel.createFromWebviewPanel(...)` with the panel VS Code already created.
+2. **Command-driven** — Handlers such as `waitThenCreateOrRevealPanel` wait for Python init, then `DataViewerPanel.createOrReveal(...)`, which may create a new `WebviewPanel` or focus an existing one depending on settings.
+
+### Deactivation
+
+`deactivate` aborts active Python processes via `DataProcessor` / `PythonManager`, clears the static panel map on `DataViewerPanel`, disposes `ErrorBoundary`, and shuts down `Logger`.
+
+---
+
+## Repository layout (extension-relevant)
+
+| Area                  | Role                                                                                           |
+| --------------------- | ---------------------------------------------------------------------------------------------- |
+| `src/extension.ts`    | Activation, command registration, workspace listeners, Python refresh orchestration            |
+| `src/*.ts` (root)     | Core types (`types.ts`), `DataViewerPanel`, `ScientificDataEditorProvider`, `StatusBarItem`    |
+| `src/common/`         | Config keys, logging, VS Code helpers, errors, healthcheck, small utilities                    |
+| `src/python/`         | Interpreter selection, uv-backed optional env, subprocess execution, `DataProcessor` → scripts |
+| `src/panel/`          | Webview HTML/CSS/JS assembly, `UIController`, `MessageBus`, `AppState`, theming                |
+| `src/panel/webview/`  | **`webview-script.js`** (large UI client), **`styles.css`** — read at runtime by generators    |
+| `src/outline/`        | Sidebar outline tree and header derivation                                                     |
+| `python/` (repo root) | **`get_data_info.py`** merged CLI (`info` / `plot` modes) and auxiliary scripts/notebooks      |
+| `test/`               | Mocha-based tests (`**.test.js`), bootstrapped via `test/suite/index.ts`                       |
+| `package.json`        | `activationEvents`, `contributes.commands`, custom editors, languages, views                   |
+
+---
+
+## Modules and how they interact
+
+### Extension orchestration (`extension.ts` + `common/`)
+
+- **`common/config.ts`** — Central place for setting keys, command IDs, and typed accessors used across the extension.
+- **`common/vscodeutils.ts`** — Display name, version, supported extensions from `package.json`, dialogs, and shared message helpers.
+- **`common/Logger.ts`** — Output channel logging; dev workflows often pair this with webview developer tools.
+- **`common/ErrorBoundary.ts`** — Per-component and global error hooks; `UIController` registers a named handler that surfaces errors into the webview via `MessageBus`.
+- **`common/HealthcheckManager.ts`** — On-demand diagnostic report (panels, Python, config, etc.); invoked from the healthcheck command.
+- **`common/utils.ts`**, **`package-types.ts`** — Small shared helpers and structural types for package metadata.
+
+**Interaction:** `extension.ts` wires configuration listeners and commands to `PythonManager`, `DataViewerPanel`, `OutlineProvider`, and `HealthcheckManager`. `refreshPython` is the main “reconcile environment + UI” path after config or workspace changes.
+
+### Python stack (`src/python/` + root `python/`)
+
+- **`ExtensionVirtualEnvironmentManager`** — Manages an optional **extension-owned** environment (uv-based) under global storage.
+- **`ExtensionVirtualEnvironmentManagerUI`** — User-facing flow for managing that environment (command-driven).
+- **`PythonManager`** — Resolves interpreter (override setting, extension env, Microsoft Python extension, or system), validates/installs dependency sets, spawns scripts, tracks and aborts child processes (important for long plot operations).
+- **`officialPythonExtensionApiUtils`** — Optional integration with the Python extension for faster interpreter-change detection.
+- **`DataProcessor`** — Singleton facade used everywhere host-side needs data: runs `get_data_info.py` with `info` or `plot` subcommands, passes settings (thresholds, matplotlib style, plot options) as CLI args, returns typed results aligned with `types.ts`.
+
+**Interaction:** `extension.ts` constructs `PythonManager` once and passes it into `DataProcessor.createInstance`. `ScientificDataEditorProvider` and `UIController` both depend on `DataProcessor.getInstance()` (implicitly) for script execution. The webview never runs Python; it requests work through `MessageBus` → `UIController` → `DataProcessor`.
+
+### Viewer panel (`DataViewerPanel.ts`)
+
+- Owns a static **`Map` of live panels**, `getActivePanel`, `refreshPanelsWithErrors` (used after Python refresh), and a static reference to **`OutlineProvider`** set at startup.
+- Constructs **`UIController`** with callbacks that flip a local `_hasError` flag and trigger outline updates when the panel becomes active (`onDidChangeViewState`).
+- **`createOrReveal`** vs **`createFromWebviewPanel`** unify command-opened and custom-editor tabs.
+
+**Interaction:** Commands in `extension.ts` resolve to a `DataViewerPanel` instance when they need to scroll (`emitCommandScrollToHeader`) or export webview content. The outline’s “scroll to header” command looks up the panel by id from `OutlineProvider.getCurrentPanelId()`.
+
+### Panel / webview host side (`src/panel/`)
+
+- **`UIController`** — Heart of host↔webview bridging: creates **`StateManager`**, **`MessageBus`**, subscribes to state, implements request handlers (`getDataInfo`, `createPlot`, `abortPlot`, save/open plot, `refresh`, `exportWebview`, `updateHeaders`, notifications, etc.), calls **`DataProcessor`**, updates HTML via **`HTMLGenerator`**, and coordinates with **`ThemeManager`**.
+- **`communication/MessageBus.ts`** + **`MessageTypes.ts`** — Typed request/response/event messages over `webview.postMessage` / `onDidReceiveMessage`.
+- **`HTMLGenerator.ts`** — Composes the document shell; inlines CSS from **`CSSGenerator`** and JS from **`JavaScriptGenerator`**.
+- **`CSSGenerator` / `JavaScriptGenerator`** — Read `src/panel/webview/styles.css` and `webview-script.js` from disk (with reload in dev mode when enabled), so the running webview is largely **one HTML blob** with embedded assets.
+- **`state/AppState.ts`** — Reducer-style state for the current file, loaded metadata, UI selections, and cached extension config snapshots pushed to the webview.
+
+**Interaction:** The webview script sends requests; `MessageBus` dispatches to `UIController` methods; results and events flow back to update DOM/state in the iframe. Plotting and file introspection always round-trip through Python on the extension host.
+
+### Outline (`src/outline/`)
+
+- **`OutlineProvider`** — `TreeDataProvider` for the contributed outline view; stores headers per panel id, supports expand/collapse state, and attaches **`CMD_SCROLL_TO_HEADER`** to items.
+- **`HeaderExtractor`** — Builds a hierarchical **`HeaderItem`** tree from loaded data metadata (and related helpers for ids); used when a panel updates the outline.
+
+**Interaction:** When a panel becomes visible, `DataViewerPanel` either restores cached headers for that panel id or recomputes them from `UIController.getDataInfo()` and calls `outlineProvider.updateHeaders`. The command `scrollToHeader` bridges the tree back to the correct `DataViewerPanel`.
+
+### Custom editor glue (`ScientificDataEditorProvider.ts`)
+
+Implements `CustomReadonlyEditorProvider`: lightweight `CustomDocument` (uri + dispose), then **`resolveCustomEditor`** reuses VS Code’s `WebviewPanel` and hands off to `DataViewerPanel.createFromWebviewPanel`. This avoids double panel creation and reduces flicker compared to always opening a second webview.
+
+### Status bar (`StatusBarItem.ts`)
+
+Updated from `refreshPython` with `PythonManager.getCurrentEnvironmentInfo()` so users see which interpreter and readiness state the extension is using.
+
+---
+
+## `package.json` contributions (mental model)
+
+- **`activationEvents`** — Lazy activation on relevant languages and virtual file systems (e.g. Zarr).
+- **`customEditors`** — Multiple view types (`netcdfEditor`, `hdf5Editor`, …) all backed by the **same** `ScientificDataEditorProvider` instance registered repeatedly with different ids.
+- **Commands** — Open viewer (file/folder/selection), Python refresh and package install, logs, settings, devtools, outline expand-all, export webview, dev mode toggle, healthcheck.
+- **Views** — Outline view id referenced in config and `extension.ts` when creating the tree.
+
+---
+
+## Legacy and maintenance realities
+
+- **`webview-script.js`** is very large: most product behavior (rendering xarray HTML, plot controls, trees, export) lives there. Changing behavior often means tracing **message types** in `MessageTypes.ts` / `MessageBus` / `UIController` **and** the corresponding handlers in the webview script.
+- **Singletons** (`DataProcessor`, `ErrorBoundary`, `HealthcheckManager`, static maps on `DataViewerPanel`) make testing and reasoning about lifecycle order easier for quick fixes but harder for isolation; activation order in the Mermaid diagram matters.
+- **Python CLI** is consolidated in **`python/get_data_info.py`** (subcommands), while older docs or comments may still refer to separate scripts conceptually.
+
+---
+
+## Related documentation
+
+Existing deeper or topic-specific notes under `docs/` (for example `TECHNICAL_ARCHITECTURE.md`, `DEVELOPMENT.md`, release notes) may overlap or predate this snapshot; prefer **this file’s module boundaries** when reconciling with older diagrams.

--- a/docs/RELEASE_NOTES_0.11.2.md
+++ b/docs/RELEASE_NOTES_0.11.2.md
@@ -1,6 +1,6 @@
 # Scientific Data Viewer v0.11.2 Release Notes
 
-**TL;DR** — NetCDF files with invalid CF datetime `units` no longer block the viewer: the backend retries with `decode_cf=False` and the File Information section labels degraded mode.
+**TL;DR** — Degraded `decode_cf` fallback for broken CF time units ([#136](https://github.com/etienneschalk/scientific-data-viewer/issues/136)); HTML-escaped attribute values for compound dtypes ([#137](https://github.com/etienneschalk/scientific-data-viewer/issues/137)).
 
 ## Degraded mode for broken CF time units ([#136](https://github.com/etienneschalk/scientific-data-viewer/issues/136))
 
@@ -16,10 +16,12 @@ Some NetCDF files ship variables whose `units` attribute looks like a time axis 
 
 Plotting uses the same open path, so plots work on these files as well (raw numeric values, no decoded datetimes).
 
-## Manual test file
+**Manual test:** `sample-data/broken_datetime_variable.nc`
 
-After running `python/create_sample_data.py` (or `setup.sh`), open:
+## Attribute display: escape HTML special characters ([#137](https://github.com/etienneschalk/scientific-data-viewer/issues/137))
 
-`sample-data/broken_datetime_variable.nc`
+Compound / structured dtypes (NumPy [structured arrays](https://numpy.org/doc/stable/user/basics.rec.html), NetCDF [user-defined types](https://docs.unidata.ucar.edu/netcdf-c/4.9.3/user_defined_types.html)) expose encoding metadata whose string form contains `<` (e.g. `'<i4'`). Unescaped values were parsed as HTML tags, so the visible attribute text was truncated at the first angle bracket while the `title` tooltip stayed correct.
 
-You should see the degraded-mode cue and the `delta` variable metadata.
+Flat attribute rows (group, variable, coordinate) now use the existing webview `escapeHtml()` helper.
+
+**Manual test:** `sample-data/compound_dtype_variable.nc` — expand variable **`pets`** → **`__xarray_encoding.dtype`**; the full dtype string should display.

--- a/docs/RELEASE_NOTES_0.11.2.md
+++ b/docs/RELEASE_NOTES_0.11.2.md
@@ -1,0 +1,25 @@
+# Scientific Data Viewer v0.11.2 Release Notes
+
+**TL;DR** — NetCDF files with invalid CF datetime `units` no longer block the viewer: the backend retries with `decode_cf=False` and the File Information section labels degraded mode.
+
+## Degraded mode for broken CF time units ([#136](https://github.com/etienneschalk/scientific-data-viewer/issues/136))
+
+Some NetCDF files ship variables whose `units` attribute looks like a time axis but cannot be parsed (e.g. `(days since 2000-01-01 00:00:00)-1`). With default xarray settings, `open_datatree` raises:
+
+`ValueError: unable to decode time units ...`
+
+**Behaviour in 0.11.2**
+
+1. Open with `decode_cf=True` (unchanged default).
+2. If that specific error occurs, log a warning and reopen with `decode_cf=False`.
+3. In the webview **File Information** section, show: **Mode: degraded (decode_cf=False)**.
+
+Plotting uses the same open path, so plots work on these files as well (raw numeric values, no decoded datetimes).
+
+## Manual test file
+
+After running `python/create_sample_data.py` (or `setup.sh`), open:
+
+`sample-data/broken_datetime_variable.nc`
+
+You should see the degraded-mode cue and the `delta` variable metadata.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "scientific-data-viewer",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "scientific-data-viewer",
-            "version": "0.11.1",
+            "version": "0.11.2",
             "dependencies": {
                 "axios": "^1.6.0",
                 "jsdom": "^27.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -203,9 +203,9 @@
             }
         },
         "node_modules/@azure/identity": {
-            "version": "4.13.0",
-            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.0.tgz",
-            "integrity": "sha512-uWC0fssc+hs1TGGVkkghiaFkkS7NkTxfnCH+Hdg+yTehTpMcehpok4PgUKKdyCH+9ldu6FhiHRv84Ntqj1vVcw==",
+            "version": "4.13.1",
+            "resolved": "https://registry.npmjs.org/@azure/identity/-/identity-4.13.1.tgz",
+            "integrity": "sha512-5C/2WD5Vb1lHnZS16dNQRPMjN6oV/Upba+C9nBIs15PmOi6A3ZGs4Lr2u60zw4S04gi+u3cEXiqTVP7M4Pz3kw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -216,8 +216,8 @@
                 "@azure/core-tracing": "^1.0.0",
                 "@azure/core-util": "^1.11.0",
                 "@azure/logger": "^1.0.0",
-                "@azure/msal-browser": "^4.2.0",
-                "@azure/msal-node": "^3.5.0",
+                "@azure/msal-browser": "^5.5.0",
+                "@azure/msal-node": "^5.1.0",
                 "open": "^10.1.0",
                 "tslib": "^2.2.0"
             },
@@ -240,22 +240,22 @@
             }
         },
         "node_modules/@azure/msal-browser": {
-            "version": "4.29.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-4.29.0.tgz",
-            "integrity": "sha512-/f3eHkSNUTl6DLQHm+bKecjBKcRQxbd/XLx8lvSYp8Nl/HRyPuIPOijt9Dt0sH50/SxOwQ62RnFCmFlGK+bR/w==",
+            "version": "5.14.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.14.0.tgz",
+            "integrity": "sha512-Dfl7hPZe9/JJwRhFFXHq2z1oHYBuGubmff3kWXOsd1AGgyXlqjNYAWuN/1JL/ZrcZBs8TKMjGSil6Rcc7E8VPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.15.0"
+                "@azure/msal-common": "16.9.0"
             },
             "engines": {
                 "node": ">=0.8.0"
             }
         },
         "node_modules/@azure/msal-common": {
-            "version": "15.15.0",
-            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-15.15.0.tgz",
-            "integrity": "sha512-/n+bN0AKlVa+AOcETkJSKj38+bvFs78BaP4rNtv3MJCmPH0YrHiskMRe74OhyZ5DZjGISlFyxqvf9/4QVEi2tw==",
+            "version": "16.9.0",
+            "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.9.0.tgz",
+            "integrity": "sha512-1MWGjqgUCRAYgLmVFZKp7fs3Rg1TFvIMgywY8ze2olNVvLlJoRThuoziWSDJuwwyJI5L4rnLb9Tyt5D9GvSLPw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -263,18 +263,17 @@
             }
         },
         "node_modules/@azure/msal-node": {
-            "version": "3.8.8",
-            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-3.8.8.tgz",
-            "integrity": "sha512-+f1VrJH1iI517t4zgmuhqORja0bL6LDQXfBqkjuMmfTYXTQQnh1EvwwxO3UbKLT05N0obF72SRHFrC1RBDv5Gg==",
+            "version": "5.2.5",
+            "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.2.5.tgz",
+            "integrity": "sha512-RUuewWk9JvWJS5Yiy8/74Lm1rQAWlrU/qg/Bgtk1jIauVRtnb9XKwS5Xg0J+Whwjesq9EVrBIFgQEP8vHxgezA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@azure/msal-common": "15.15.0",
-                "jsonwebtoken": "^9.0.0",
-                "uuid": "^8.3.0"
+                "@azure/msal-common": "16.9.0",
+                "jsonwebtoken": "^9.0.0"
             },
             "engines": {
-                "node": ">=16"
+                "node": ">=20"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1464,9 +1463,9 @@
             }
         },
         "node_modules/@vscode/vsce/node_modules/brace-expansion": {
-            "version": "5.0.5",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1688,14 +1687,40 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.13.6",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-            "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.0.tgz",
+            "integrity": "sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.15.11",
+                "follow-redirects": "^1.16.0",
                 "form-data": "^4.0.5",
-                "proxy-from-env": "^1.1.0"
+                "https-proxy-agent": "^5.0.1",
+                "proxy-from-env": "^2.1.0"
+            }
+        },
+        "node_modules/axios/node_modules/agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "license": "MIT",
+            "dependencies": {
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6.0.0"
+            }
+        },
+        "node_modules/axios/node_modules/https-proxy-agent": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+            "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/azure-devops-node-api": {
@@ -3099,9 +3124,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
             "dev": true,
             "funding": [
                 {
@@ -3211,9 +3236,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.11",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "version": "1.16.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
             "funding": [
                 {
                     "type": "individual",
@@ -3248,16 +3273,16 @@
             }
         },
         "node_modules/form-data": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-            "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+            "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
-                "mime-types": "^2.1.12"
+                "hasown": "^2.0.4",
+                "mime-types": "^2.1.35"
             },
             "engines": {
                 "node": ">= 6"
@@ -3532,9 +3557,9 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
             "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -3980,10 +4005,20 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodeca"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1"
@@ -4226,10 +4261,20 @@
             }
         },
         "node_modules/linkify-it": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
-            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+            "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "uc.micro": "^2.0.0"
@@ -4553,15 +4598,25 @@
             }
         },
         "node_modules/markdown-it": {
-            "version": "14.1.1",
-            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
-            "integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+            "version": "14.2.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+            "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
             "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/puzrin"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/markdown-it"
+                }
+            ],
             "license": "MIT",
             "dependencies": {
                 "argparse": "^2.0.1",
                 "entities": "^4.4.0",
-                "linkify-it": "^5.0.0",
+                "linkify-it": "^5.0.1",
                 "mdurl": "^2.0.0",
                 "punycode.js": "^2.3.1",
                 "uc.micro": "^2.1.0"
@@ -5451,10 +5506,13 @@
             "license": "MIT"
         },
         "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-            "license": "MIT"
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/pump": {
             "version": "3.0.4",
@@ -5488,9 +5546,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+            "version": "6.15.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+            "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -6643,9 +6701,9 @@
             "license": "MIT"
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6873,16 +6931,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "uuid": "dist/bin/uuid"
-            }
-        },
         "node_modules/validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -7103,9 +7151,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-            "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "scientific-data-viewer",
     "displayName": "Scientific Data Viewer",
     "description": "A VSCode extension for viewing scientific data files including NetCDF, Zarr, HDF5, GRIB, GeoTIFF, and more",
-    "version": "0.11.1",
+    "version": "0.11.2",
     "publisher": "eschalk0",
     "icon": "media/icon.png",
     "engines": {

--- a/python/create_sample_data.py
+++ b/python/create_sample_data.py
@@ -1193,6 +1193,43 @@ def create_sample_netcdf_broken_datetime_variable():
     return output_file
 
 
+def create_sample_netcdf_compound_dtype_variable():
+    """Create a NetCDF file with a compound dtype (issue #137 attribute-display repro).
+
+    Based on the NumPy structured-array pets example (basics.rec). netCDF4 compound
+    types use fixed-length bytes (S10) instead of Unicode (U10).
+    """
+    output_file = "compound_dtype_variable.nc"
+
+    if os.path.exists(output_file):
+        print(f"📄 NetCDF file {output_file} already exists. Skipping creation.")
+        print("  🔄 To regenerate, please delete the existing file first.")
+        return output_file
+
+    if not _optional_pkg_available("netCDF4"):
+        print("⚠️  netCDF4 not available; skipping compound_dtype_variable.nc")
+        return None
+
+    import netCDF4
+
+    print("🐾 Creating NetCDF file with compound dtype (structured array)...")
+
+    # https://numpy.org/doc/stable/user/basics.rec.html — Rex/Fido pets example
+    pet_dtype = np.dtype([("name", "S10"), ("age", "i4"), ("weight", "f4")])
+    pets = np.array([(b"Rex", 9, 81.0), (b"Fido", 3, 27.0)], dtype=pet_dtype)
+
+    with netCDF4.Dataset(output_file, "w") as ds:
+        ds.createDimension("pet", len(pets))
+        pet_record = ds.createCompoundType(pet_dtype, "pet_record")
+        var = ds.createVariable("pets", pet_record, ("pet",))
+        var[:] = pets
+        var.long_name = "Pet records (numpy structured array example, issue #137)"
+        ds.title = "Compound dtype sample (issue #137)"
+
+    print(f"✅ Created {output_file}")
+    return output_file
+
+
 def create_sample_netcdf4():
     """Create a sample NetCDF4 file with advanced features."""
     output_file = "sample_data.nc4"
@@ -5410,6 +5447,12 @@ def main(do_create_disposable_files: bool = False):
         if broken_datetime_netcdf_file:
             created_files.append(
                 (broken_datetime_netcdf_file, "NetCDF (Broken Datetime Units)")
+            )
+
+        compound_dtype_netcdf_file = create_sample_netcdf_compound_dtype_variable()
+        if compound_dtype_netcdf_file:
+            created_files.append(
+                (compound_dtype_netcdf_file, "NetCDF (Compound Dtype)")
             )
 
         print("\n📁 Creating HDF5 files...")

--- a/python/create_sample_data.py
+++ b/python/create_sample_data.py
@@ -1163,6 +1163,36 @@ def create_sample_jp2():
     return output_file
 
 
+def create_sample_netcdf_broken_datetime_variable():
+    """Create a NetCDF file with invalid time units (issue #136 degraded-mode test)."""
+    output_file = "broken_datetime_variable.nc"
+
+    if os.path.exists(output_file):
+        print(f"📄 NetCDF file {output_file} already exists. Skipping creation.")
+        print("  🔄 To regenerate, please delete the existing file first.")
+        return output_file
+
+    if not _optional_pkg_available("netCDF4"):
+        print("⚠️  netCDF4 not available; skipping broken_datetime_variable.nc")
+        return None
+
+    import netCDF4
+
+    print("🌡️ Creating NetCDF file with broken datetime units...")
+
+    with netCDF4.Dataset(output_file, "w") as ds:
+        ds.createDimension("x", 3)
+        ds.createDimension("y", 2)
+        var = ds.createVariable("delta", "f4", ("y", "x"))
+        var[:] = np.arange(6, dtype=np.float32).reshape(2, 3)
+        var.units = "(days since 2000-01-01 00:00:00)-1"
+        var.long_name = "Variable with invalid CF time units"
+        ds.title = "Broken datetime variable sample (issue #136)"
+
+    print(f"✅ Created {output_file}")
+    return output_file
+
+
 def create_sample_netcdf4():
     """Create a sample NetCDF4 file with advanced features."""
     output_file = "sample_data.nc4"
@@ -5375,6 +5405,12 @@ def main(do_create_disposable_files: bool = False):
         no_attrs_netcdf_file = create_sample_netcdf_no_attributes()
         if no_attrs_netcdf_file:
             created_files.append((no_attrs_netcdf_file, "NetCDF (No Attributes)"))
+
+        broken_datetime_netcdf_file = create_sample_netcdf_broken_datetime_variable()
+        if broken_datetime_netcdf_file:
+            created_files.append(
+                (broken_datetime_netcdf_file, "NetCDF (Broken Datetime Units)")
+            )
 
         print("\n📁 Creating HDF5 files...")
         hdf5_file = create_sample_hdf5()

--- a/python/get_data_info.py
+++ b/python/get_data_info.py
@@ -443,6 +443,8 @@ class FileInfoResult:
         Detailed format information
     used_engine : str
         xarray engine used to read the file
+    decode_cf_degraded : bool
+        True when the file was opened with decode_cf=False after a CF time decode failure
     fileSize : int
         File size in bytes
     xarray_html_repr : str
@@ -479,6 +481,7 @@ class FileInfoResult:
     xarray_html_repr_flattened: dict[str, str] = field(repr=False)
     xarray_text_repr_flattened: dict[str, str] = field(repr=False)
     datetime_variables: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    decode_cf_degraded: bool = False
     # Format: {group_name: [{"name": var_name, "min": min_value, "max": max_value}, ...]}
 
 
@@ -642,11 +645,34 @@ def detect_file_format(file_path: Path) -> FileFormatInfo:
     )
 
 
+def _is_decode_cf_time_error(exc: BaseException) -> bool:
+    return isinstance(exc, ValueError) and "unable to decode time units" in str(exc)
+
+
+def _open_with_decode_cf_fallback(open_fn: Callable[[bool], Any]) -> tuple[Any, bool]:
+    try:
+        return open_fn(True), False
+    except Exception as exc:
+        if not _is_decode_cf_time_error(exc):
+            raise
+        logger.warning(
+            f"CF time decode failed ({exc!r}); retrying with decode_cf=False"
+        )
+        return open_fn(False), True
+
+
+def _xr_open_kwargs(engine: str, decode_cf: bool) -> dict[str, Any]:
+    kwargs = DEFAULT_XR_OPEN_KWARGS[engine].copy()
+    if "decode_cf" in kwargs:
+        kwargs["decode_cf"] = decode_cf
+    return kwargs
+
+
 def open_datatree_with_fallback(
     file_path: Path,
     file_format_info: FileFormatInfo,
     convert_bands_to_variables: bool = False,
-) -> "tuple[xr.DataTree | DictOfDatasets, str]":
+) -> "tuple[xr.DataTree | DictOfDatasets, str, bool]":
     """Open datatree or dataset with fallback to different engines.
 
     Attempts to open the file as a DataTree first, then falls back to
@@ -662,8 +688,8 @@ def open_datatree_with_fallback(
     Returns
     -------
     tuple
-        Tuple containing (data_structure, engine_name) where data_structure
-        is either a DataTree or DictOfDatasets
+        Tuple containing (data_structure, engine_name, decode_cf_degraded) where
+        data_structure is either a DataTree or DictOfDatasets
 
     Raises
     ------
@@ -688,7 +714,7 @@ def open_datatree_with_fallback(
             xds = cdflib.xarray.cdf_to_xarray(file_path)
             # cdflib returns a Dataset, wrap it in a dict for consistency
             xds_dict: DictOfDatasets = {"/": xds}
-            return xds_dict, "cdflib"
+            return xds_dict, "cdflib", False
         except Exception as exc:
             logger.error(f"Failed to open CDF file with cdflib: {exc!r}")
             # If cdflib fails and it's the only engine, raise the error
@@ -720,13 +746,15 @@ def open_datatree_with_fallback(
                 )
 
             if can_use_datatree(engine):
-                xdt_or_xds = xr.open_datatree(
-                    file_path,
-                    engine=engine,
-                    **DEFAULT_XR_OPEN_KWARGS[engine],
-                    backend_kwargs=backend_kwargs,
+                xdt_or_xds, decode_cf_degraded = _open_with_decode_cf_fallback(
+                    lambda decode_cf, eng=engine, bk=backend_kwargs: xr.open_datatree(
+                        file_path,
+                        engine=eng,
+                        **_xr_open_kwargs(eng, decode_cf),
+                        backend_kwargs=bk,
+                    )
                 )
-                return xdt_or_xds, engine
+                return xdt_or_xds, engine, decode_cf_degraded
             else:
                 # Attempt to replace DataTree by a dict of Datasets
                 if engine == "netcdf4" and check_package_availability("netCDF4"):
@@ -746,39 +774,52 @@ def open_datatree_with_fallback(
                 else:
                     groups = ["/"]
 
-                xds_dict: DictOfDatasets = {
-                    group: (
-                        xr.open_dataset(
+                def open_group(
+                    decode_cf: bool,
+                    group: str = "/",
+                    *,
+                    eng: str = engine,
+                    bk: dict[str, Any] = backend_kwargs,
+                ) -> xr.Dataset:
+                    kwargs = _xr_open_kwargs(eng, decode_cf)
+                    if group == "/":
+                        return xr.open_dataset(
                             file_path,
-                            engine=engine,
-                            **DEFAULT_XR_OPEN_KWARGS[engine],
-                            backend_kwargs=backend_kwargs,
+                            engine=eng,
+                            **kwargs,
+                            backend_kwargs=bk,
                         )
-                        if group == "/"
-                        else xr.open_dataset(
-                            file_path,
-                            engine=engine,
-                            **DEFAULT_XR_OPEN_KWARGS[engine],
-                            backend_kwargs=backend_kwargs,
-                            group=group,
-                        )
+                    return xr.open_dataset(
+                        file_path,
+                        engine=eng,
+                        **kwargs,
+                        backend_kwargs=bk,
+                        group=group,
                     )
-                    for group in groups
-                }
-                return xds_dict, engine
+
+                root_ds, decode_cf_degraded = _open_with_decode_cf_fallback(open_group)
+                xds_dict: DictOfDatasets = {"/": root_ds}
+                decode_cf = not decode_cf_degraded
+                for group in groups:
+                    if group == "/":
+                        continue
+                    xds_dict[group] = open_group(decode_cf, group)
+                return xds_dict, engine, decode_cf_degraded
         except NotImplementedError as exc:
             # Fallback on dataset
             logger.warning(
                 f"Opening file as DataTree is not implemented with engine {engine}: {exc!r}"
             )
             logger.warning("Fallback to opening file as Dataset")
-            xds = xr.open_dataset(
-                file_path,
-                engine=engine,
-                **DEFAULT_XR_OPEN_KWARGS[engine],
-                backend_kwargs=DEFAULT_ENGINE_BACKEND_KWARGS[engine],
+            xds, decode_cf_degraded = _open_with_decode_cf_fallback(
+                lambda decode_cf, eng=engine: xr.open_dataset(
+                    file_path,
+                    engine=eng,
+                    **_xr_open_kwargs(eng, decode_cf),
+                    backend_kwargs=DEFAULT_ENGINE_BACKEND_KWARGS[eng],
+                )
             )
-            return xds, engine
+            return xds, engine, decode_cf_degraded
         except Exception as exc:
             exceptions.append(exc)
             continue
@@ -1673,7 +1714,7 @@ def create_plot(
             plt.style.use("default")
 
         # Open dataset with fallback
-        xds_or_xdt, used_engine = open_datatree_with_fallback(
+        xds_or_xdt, used_engine, _decode_cf_degraded = open_datatree_with_fallback(
             file_path, file_format_info, convert_bands_to_variables
         )
 
@@ -2125,7 +2166,7 @@ def get_file_info(
 
     try:
         # Open dataset with fallback
-        xds_or_xdt, used_engine = open_datatree_with_fallback(
+        xds_or_xdt, used_engine, decode_cf_degraded = open_datatree_with_fallback(
             file_path, file_format_info, convert_bands_to_variables
         )
     except ImportError:
@@ -2198,6 +2239,7 @@ def get_file_info(
         info = FileInfoResult(
             format_info=file_format_info,
             used_engine=used_engine,
+            decode_cf_degraded=decode_cf_degraded,
             fileSize=os.path.getsize(file_path),
             xarray_html_repr=repr_html,
             xarray_text_repr=repr_text,

--- a/python/test_compound_dtype_sample.py
+++ b/python/test_compound_dtype_sample.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for compound-dtype sample data (issue #137 reproduction)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import xarray as xr
+from create_sample_data import create_sample_netcdf_compound_dtype_variable
+from get_data_info import get_file_info
+
+
+def test_compound_dtype_sample_opens_and_encoding_dtype_has_angle_brackets() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp)
+        cwd = Path.cwd()
+        try:
+            import os
+
+            os.chdir(path)
+            output = create_sample_netcdf_compound_dtype_variable()
+            assert output == "compound_dtype_variable.nc"
+            nc_path = path / output
+
+            xr.open_datatree(nc_path).close()
+
+            result = get_file_info(nc_path)
+            pets = next(v for v in result.variables_flattened["/"] if v.name == "pets")
+            dtype_attr = pets.attributes["__xarray_encoding.dtype"]
+            dtype_str = str(dtype_attr)
+            assert "<" in dtype_str, (
+                "encoding dtype should contain '<' (endianness) to reproduce #137"
+            )
+        finally:
+            os.chdir(cwd)

--- a/python/test_decode_cf_fallback.py
+++ b/python/test_decode_cf_fallback.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Tests for decode_cf degraded-mode fallback (issue #136)."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import netCDF4
+import numpy as np
+import pytest
+import xarray as xr
+from get_data_info import (
+    _is_decode_cf_time_error,
+    detect_file_format,
+    get_file_info,
+    open_datatree_with_fallback,
+)
+
+
+def _write_broken_time_units_nc(path: Path) -> None:
+    with netCDF4.Dataset(path, "w") as ds:
+        ds.createDimension("x", 2)
+        var = ds.createVariable("delta", "f4", ("x",))
+        var[:] = np.array([1.0, 2.0], dtype=np.float32)
+        var.units = "(days since 2000-01-01 00:00:00)-1"
+
+
+def test_is_decode_cf_time_error_matches_value_error_message() -> None:
+    exc = ValueError(
+        "unable to decode time units '(days since 2000-01-01 00:00:00)-1' "
+        "with 'the default calendar'."
+    )
+    assert _is_decode_cf_time_error(exc)
+    assert not _is_decode_cf_time_error(ValueError("other error"))
+
+
+def test_open_datatree_with_fallback_uses_decode_cf_false() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "broken.nc"
+        _write_broken_time_units_nc(path)
+
+        with pytest.raises(ValueError, match="unable to decode time units"):
+            xr.open_datatree(path)
+
+        fmt = detect_file_format(path)
+        xdt, engine, degraded = open_datatree_with_fallback(path, fmt)
+        try:
+            assert degraded is True
+            assert engine == "netcdf4"
+            assert isinstance(xdt, xr.DataTree)
+        finally:
+            xdt.close()
+
+
+def test_get_file_info_reports_decode_cf_degraded() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "broken.nc"
+        _write_broken_time_units_nc(path)
+
+        result = get_file_info(path)
+        assert result.decode_cf_degraded is True
+        assert result.used_engine == "netcdf4"
+        assert "delta" in {v.name for v in result.variables_flattened["/"]}

--- a/src/panel/webview/webview-script.js
+++ b/src/panel/webview/webview-script.js
@@ -834,6 +834,9 @@ function renderFileInformation(data) {
             }
         `;
     }
+    if (data.decode_cf_degraded) {
+        formatInfo += /*html*/ ` · <strong>Mode:</strong> degraded (decode_cf=False)`;
+    }
     formatInfo += '</p>';
     return formatInfo;
 }

--- a/src/panel/webview/webview-script.js
+++ b/src/panel/webview/webview-script.js
@@ -526,6 +526,15 @@ function escapeHtml(unsafe) {
         .replaceAll("'", '&#039;');
 }
 
+function attributeValueStrings(value) {
+    const valueStr = typeof value === 'string' ? value : JSON.stringify(value);
+    const displayStr =
+        valueStr.length > MAX_ATTR_DISPLAY_STR_LENGTH
+            ? valueStr.slice(0, MAX_ATTR_DISPLAY_STR_LENGTH) + '…'
+            : valueStr;
+    return { valueStr, displayStr };
+}
+
 function showDegradedModeIndicator() {
     // Add a visual indicator that we're in degraded mode
     const indicator = document.createElement('span');
@@ -1209,12 +1218,7 @@ function renderAttributesTree(attrsObj, groupName, idParts) {
                         <div class="attributes-tree-children">${items}</div>
                     </details>`;
             }
-            const valueStr =
-                typeof value === 'string' ? value : JSON.stringify(value);
-            const displayStr =
-                valueStr.length > MAX_ATTR_DISPLAY_STR_LENGTH
-                    ? valueStr.slice(0, MAX_ATTR_DISPLAY_STR_LENGTH) + '…'
-                    : valueStr;
+            const { valueStr, displayStr } = attributeValueStrings(value);
             return /*html*/ `
                 <div class="attribute-item" id="${leafId}">
                     <span class="attribute-name" title="${safeKey}">${safeKey}</span>
@@ -1227,12 +1231,13 @@ function renderAttributesTree(attrsObj, groupName, idParts) {
 
 function renderGroupAttributes(groupName, attrName, value) {
     const attrId = joinId(['data-group', groupName, 'attribute', attrName]);
-    const valueStr = typeof value === 'string' ? value : JSON.stringify(value);
+    const safeName = escapeHtml(String(attrName));
+    const { valueStr, displayStr } = attributeValueStrings(value);
 
     return /*html*/ `
         <div class="attribute-item" id="${attrId}">
-            <span class="attribute-name" title="${attrName}">${attrName} : </span>
-            <span class="attribute-value muted-text" title="${valueStr}">${valueStr}</span>
+            <span class="attribute-name" title="${safeName}">${safeName} : </span>
+            <span class="attribute-value muted-text" title="${escapeHtml(valueStr)}">${escapeHtml(displayStr)}</span>
         </div>
     `;
 }
@@ -1377,16 +1382,16 @@ function renderVariableAttributes(attributes, parentId) {
 
     const attributesList = Object.entries(attributes)
         .map(([attrName, value]) => {
-            const valueStr =
-                typeof value === 'string' ? value : JSON.stringify(value);
+            const safeName = escapeHtml(String(attrName));
+            const { valueStr, displayStr } = attributeValueStrings(value);
             return /*html*/ `
             <div class="attribute-item" id="${joinId([
                 parentId,
                 'attribute',
                 attrName,
             ])}">
-                <span class="attribute-name" title="${attrName}">${attrName} : </span>
-                <span class="attribute-value muted-text" title="${valueStr}">${valueStr}</span>
+                <span class="attribute-name" title="${safeName}">${safeName} : </span>
+                <span class="attribute-value muted-text" title="${escapeHtml(valueStr)}">${escapeHtml(displayStr)}</span>
             </div>
         `;
         })

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,7 @@ export interface DataInfoResult {
     format: string;
     format_info: DataInfoFormatInfo;
     used_engine: string;
+    decode_cf_degraded?: boolean;
     fileSize: number;
     xarray_html_repr: string;
     xarray_text_repr: string;
@@ -111,6 +112,7 @@ export interface DataInfoResult {
     format: string;
     format_info: DataInfoFormatInfo;
     used_engine: string;
+    decode_cf_degraded?: boolean;
     fileSize: number;
     xarray_html_repr: string;
     xarray_text_repr: string;


### PR DESCRIPTION
## Summary

Release **v0.11.2** with two bug fixes for opening and displaying difficult NetCDF files:

- **[#136](https://github.com/etienneschalk/scientific-data-viewer/issues/136)** — Fallback to `decode_cf=False` when CF time-unit decoding fails, with a degraded-mode cue in File Information.
- **[#137](https://github.com/etienneschalk/scientific-data-viewer/issues/137)** — Escape HTML in flat attribute displays so compound-dtype encoding strings (e.g. `'<i4'`) are not truncated at the first `<`.

## Changes

### #136 — Degraded mode for broken CF time units

**Problem:** NetCDF files with invalid datetime `units` (e.g. `(days since 2000-01-01 00:00:00)-1`) cause `xr.open_datatree` to raise `ValueError: unable to decode time units ...`, blocking the viewer.

**Solution:**
- `open_datatree_with_fallback()` tries `decode_cf=True` first, then retries with `decode_cf=False` on that specific error.
- Applies to DataTree, per-group dataset opens, and the existing `NotImplementedError` dataset fallback.
- `FileInfoResult.decode_cf_degraded` is exposed to the webview.
- File Information shows **Mode: degraded (decode_cf=False)** when the fallback was used.

**Files:** `python/get_data_info.py`, `src/types.ts`, `src/panel/webview/webview-script.js`

### #137 — Attribute display HTML escaping

**Problem:** Attribute values containing `<` (common in `__xarray_encoding.dtype` for compound/structured dtypes) were inserted raw into HTML. The browser treated them as tags, truncating the visible text; the `title` tooltip still showed the full value.

**Solution:**
- Reuse existing `escapeHtml()` in `renderGroupAttributes` and `renderVariableAttributes`.
- Add shared `attributeValueStrings()` helper (also used by `renderAttributesTree`).

**Files:** `src/panel/webview/webview-script.js`

### Sample data & tests

| File | Purpose |
|------|---------|
| `sample-data/broken_datetime_variable.nc` | Manual test for #136 degraded mode |
| `sample-data/compound_dtype_variable.nc` | Manual test for #137 (NumPy structured-array pets example) |
| `python/test_decode_cf_fallback.py` | 3 tests for decode_cf fallback |
| `python/test_compound_dtype_sample.py` | Verifies compound sample opens and dtype string contains `<` |

Both samples are generated by `python/create_sample_data.py`.

### Release docs

- Version bump to **0.11.2** (`package.json`, `package-lock.json`, `README.md`)
- `CHANGELOG.md` and `docs/RELEASE_NOTES_0.11.2.md` updated

## Commits

```
f014ea7 Add decode_cf degraded mode for broken CF time units (#136)
1127a99 Fix attribute display truncation for HTML special chars (#137)
```

## Test plan

- [x] `cd python && pytest test_decode_cf_fallback.py test_compound_dtype_sample.py -v`
- [x] Run `python/create_sample_data.py` (or `setup.sh`) to generate sample files
- [x] Open `sample-data/broken_datetime_variable.nc` — file loads; File Information shows **Mode: degraded (decode_cf=False)**; `delta` variable visible
- [x] Open `sample-data/compound_dtype_variable.nc` — expand `pets` → `__xarray_encoding.dtype`; full dtype string visible (including `<i4`, `<f4`)
- [x] Smoke test a normal NetCDF (e.g. `sample_data.nc`) — no degraded mode; attributes unchanged